### PR TITLE
AB#3194 --state flag for `org add` is no longer required

### DIFF
--- a/austrakka/components/org/__init__.py
+++ b/austrakka/components/org/__init__.py
@@ -29,7 +29,7 @@ def org_list(table_format: str):
 @org.command('add', hidden=hide_admin_cmds())
 @opt_name(help_text="Organisation Name")
 @opt_abbrev(help_text="Organisation Abbreviation")
-@opt_state()
+@opt_state(required=False)
 @opt_country()
 @opt_is_active()
 def org_add(


### PR DESCRIPTION
[AB#3194](https://dev.azure.com/mduphl/66de697f-df03-4f5d-b5b4-0df4487db257/_workitems/edit/3194)