### PR TITLE
Rename to metadata validate

### DIFF
--- a/austrakka/components/metadata/__init__.py
+++ b/austrakka/components/metadata/__init__.py
@@ -34,7 +34,7 @@ def submission_append(file: BufferedReader, proforma: str):
     append_metadata(file, proforma)
 
 
-@metadata.command('check')
+@metadata.command('validate')
 @click.argument('file', type=click.File('rb'))
 @opt_proforma()
 @opt_is_append()


### PR DESCRIPTION
Rename command `metadata check` to `metadata validate`. This audience is comfortable with the term, and it's consistent with the corresponding button in the UI.