### PR TITLE
AB#3927 convenience flags for seq add

### DIFF
--- a/austrakka/components/sequence/add/__init__.py
+++ b/austrakka/components/sequence/add/__init__.py
@@ -65,4 +65,10 @@ def seq_add_fasta(
     """
     if len(shared_groups)>0 and owner_group is None:
         raise ValueError("--shared-groups requires --owner-group")
+    # For now we just forbid this completely via this mechanism
+    if owner_group is not None and len(shared_groups)==0:
+        raise ValueError("Owner group specified but no shared groups; these sequences will not be "
+                         "available within any projects. This is not usually what you want. "
+                         "If this is deliberate, please manually run "
+                         "`austrakka metadata add -p min`, or contact an AusTrakka admin.")
     add_fasta_submission(fasta_file, owner_group, shared_groups)

--- a/austrakka/components/sequence/add/__init__.py
+++ b/austrakka/components/sequence/add/__init__.py
@@ -34,13 +34,13 @@ def seq_add_fastq(
             Seq_ID: The sample name in AusTrakka\n
             filepath1: The local path of the first read to be uploaded\n
             filepath2: The local path of the second read to be uploaded
-    
+
     If no record exists for these Seq_IDs you can first add them with the
     `austrakka metadata add` command, and may use the minimal proforma if
     you wish to specify no metadata other than sample ownership.
-    
+
     Alternatively, if no record exists for these Seq_IDs and all will have
-    the same ownership and sharing settings, you can use the --owner-group 
+    the same ownership and sharing settings, you can use the --owner-group
     and --shared-groups options.
     """
     _validate_owner_and_sharing(owner_group, shared_groups)
@@ -65,23 +65,27 @@ def seq_add_fasta(
     If no record exists for these Seq_IDs you can first add them with the
     `austrakka metadata add` command, and may use the minimal proforma if
     you wish to specify no metadata other than sample ownership.
-    
+
     Alternatively, if no record exists for these Seq_IDs and all will have
-    the same ownership and sharing settings, you can use the --owner-group 
+    the same ownership and sharing settings, you can use the --owner-group
     and --shared-groups options.
     """
     _validate_owner_and_sharing(owner_group, shared_groups)
     add_fasta_submission(fasta_file, owner_group, shared_groups)
 
 
-# Validate mutual usage of options manually, not via click, as 
-# we want to return explanatory error messages about sharing 
-def _validate_owner_and_sharing(owner_group: Optional[str], shared_groups: List[str]):
-    if len(shared_groups)>0 and owner_group is None:
+# Validate mutual usage of options manually, not via click, as
+# we want to return explanatory error messages about sharing
+def _validate_owner_and_sharing(
+        owner_group: Optional[str],
+        shared_groups: List[str]):
+    if len(shared_groups) > 0 and owner_group is None:
         raise ValueError("--shared-groups requires --owner-group")
-    # For now we just forbid this completely via this mechanism; explicit metadata add is required
-    if owner_group is not None and len(shared_groups)==0:
-        raise ValueError("Owner group specified but no shared groups; these sequences will not be "
-                         "available within any projects. This is not usually what you want. "
-                         "If this is deliberate, please manually run "
-                         "`austrakka metadata add -p min`, or contact an AusTrakka admin.")
+    # For now we just forbid this completely via this mechanism; explicit
+    # metadata add is required
+    if owner_group is not None and len(shared_groups) == 0:
+        raise ValueError(
+            "Owner group specified but no shared groups; these sequences will not be "
+            "available within any projects. This is not usually what you want. "
+            "If this is deliberate, please manually run "
+            "`austrakka metadata add -p min`, or contact an AusTrakka admin.")

--- a/austrakka/components/sequence/add/__init__.py
+++ b/austrakka/components/sequence/add/__init__.py
@@ -3,7 +3,8 @@ from io import BufferedReader
 
 import click
 
-from austrakka.utils.options import opt_csv
+from austrakka.utils.options import opt_csv, \
+    opt_owner_group_for_record_creation, opt_shared_groups_for_record_creation
 from ..funcs import add_fasta_submission
 from ..funcs import add_fastq_submission
 
@@ -27,14 +28,26 @@ def seq_add_fastq(
             Seq_ID: The sample name in AusTrakka\n
             filepath1: The local path of the first read to be uploaded\n
             filepath2: The local path of the second read to be uploaded
+    
+    If no record exists for these Seq_IDs you can first add them with the
+    `austrakka metadata add` command, and may use the minimal proforma if
+    you wish to specify no metadata other than sample ownership.
+    
+    Alternatively, if no record exists for these Seq_IDs and all will have
+    the same ownership and sharing settings, you can use the --owner-goup 
+    and --shared-groups options.
     """
     add_fastq_submission(csv_file)
 
 
 @add.command('fasta')
 @click.argument('fasta_file', type=click.File('rb'))
+@opt_owner_group_for_record_creation()
+@opt_shared_groups_for_record_creation()
 def seq_add_fasta(
-        fasta_file: BufferedReader
+        fasta_file: BufferedReader,
+        owner_group,
+        shared_groups
 ):
     """
     Upload FASTA submission to AusTrakka
@@ -45,5 +58,11 @@ def seq_add_fasta(
     If no record exists for these Seq_IDs you can first add them with the
     `austrakka metadata add` command, and may use the minimal proforma if
     you wish to specify no metadata other than sample ownership.
+    
+    Alternatively, if no record exists for these Seq_IDs and all will have
+    the same ownership and sharing settings, you can use the --owner-group 
+    and --shared-groups options.
     """
-    add_fasta_submission(fasta_file)
+    if len(shared_groups)>0 and owner_group is None:
+        raise ValueError("--shared-groups requires --owner-group")
+    add_fasta_submission(fasta_file, owner_group, shared_groups)

--- a/austrakka/components/sequence/funcs.py
+++ b/austrakka/components/sequence/funcs.py
@@ -67,20 +67,24 @@ class FileHash:
     filename: str
     sha256: str
 
+
 @logger_wraps()
 def add_fasta_submission(
         fasta_file: BufferedReader,
         owner_group: str,
         shared_groups: Tuple[str]):
-    
+
     fasta_stream = TextIOWrapper(fasta_file)
     # Handle minimal metadata creation if necessary
     if owner_group is not None:
-        fasta_ids = [record.id.split(' ')[0] for record in SeqIO.parse(fasta_stream, 'fasta')]
+        fasta_ids = [
+            record.id.split(' ')[0] for record in SeqIO.parse(
+                fasta_stream, 'fasta')]
         fasta_stream.seek(0)
         min_csv_name = f"generated_min_metadata_for_{fasta_file.name}.csv"
-        _create_minimal_metadata_records(fasta_ids, min_csv_name, owner_group, shared_groups)
-        
+        _create_minimal_metadata_records(
+            fasta_ids, min_csv_name, owner_group, shared_groups)
+
     name_prefix = _calc_name_prefix(fasta_file)
 
     logger.info("Uploading sequences")
@@ -124,7 +128,8 @@ def _create_minimal_metadata_records(
         generated_csv_name: str,
         owner_group: str,
         shared_groups: Tuple[str]):
-    logger.info(f"Will create minimal metadata records for {len(seq_ids)} IDs found in FASTA file")
+    logger.info(
+        f"Will create minimal metadata records for {len(seq_ids)} IDs found in FASTA file")
     logger.info(f"Seq_IDs to create: {', '.join(seq_ids)}")
     for seq_id in seq_ids:
         # Any checking for validity of Seq_IDs here
@@ -134,7 +139,8 @@ def _create_minimal_metadata_records(
     metadata_csv.name = generated_csv_name
     metadata_csv.write(f"Seq_ID,Owner_group,Shared_groups\n".encode('utf-8'))
     for seq_id in seq_ids:
-        metadata_csv.write(f"{seq_id},{owner_group},{','.join(shared_groups)}\n".encode('utf-8'))
+        metadata_csv.write(
+            f"{seq_id},{owner_group},{','.join(shared_groups)}\n".encode('utf-8'))
     logger.info("Uploading minimal metadata")
     add_metadata(metadata_csv, 'min')
 
@@ -259,7 +265,8 @@ def add_fastq_submission(csv: BufferedReader,
     if owner_group is not None:
         seq_ids = list(csv_dataframe[FASTQ_CSV_SAMPLE_ID])
         min_csv_name = f"generated_min_metadata_for_{csv.name}.csv"
-        _create_minimal_metadata_records(seq_ids, min_csv_name, owner_group, shared_groups)
+        _create_minimal_metadata_records(
+            seq_ids, min_csv_name, owner_group, shared_groups)
 
     logger.info("Uploading sequences")
     for _, row in csv_dataframe.iterrows():

--- a/austrakka/components/sequence/funcs.py
+++ b/austrakka/components/sequence/funcs.py
@@ -76,7 +76,10 @@ def add_fasta_submission(
     fasta_stream = TextIOWrapper(fasta_file)
     # Handle minimal metadata creation if necessary
     if owner_group is not None:
-        _create_minimal_metadata_records(fasta_stream, owner_group, shared_groups)
+        fasta_ids = [record.id.split(' ')[0] for record in SeqIO.parse(fasta_stream, 'fasta')]
+        fasta_stream.seek(0)
+        min_csv_name = f"generated_min_metadata_for_{fasta_file.name}.csv"
+        _create_minimal_metadata_records(fasta_ids, min_csv_name, owner_group, shared_groups)
         
     name_prefix = _calc_name_prefix(fasta_file)
 
@@ -117,23 +120,21 @@ def add_fasta_submission(
 
 
 def _create_minimal_metadata_records(
-        fasta_stream: BufferedReader,
+        seq_ids: List[str],
+        generated_csv_name: str,
         owner_group: str,
         shared_groups: Tuple[str]):
-    fasta_ids = [record.id.split(' ')[0] for record in SeqIO.parse(fasta_stream, 'fasta')]
-    fasta_stream.seek(0)
-    logger.info(f"Will create minimal metadata records for {len(fasta_ids)} IDs found in FASTA file")
-    logger.info(f"Seq_IDs to create: {', '.join(fasta_ids)}")
-    for fasta_id in fasta_ids:
+    logger.info(f"Will create minimal metadata records for {len(seq_ids)} IDs found in FASTA file")
+    logger.info(f"Seq_IDs to create: {', '.join(seq_ids)}")
+    for seq_id in seq_ids:
         # Any checking for validity of Seq_IDs here
-        if '/' in fasta_id:
-            raise ValueError("Seq_ID values may not contain '/' characters. "
-                             "Check that FASTA IDs correspond exactly to desired SeqIDs.")
+        if '/' in seq_id:
+            raise ValueError("Seq_ID values may not contain '/' characters. ")
     metadata_csv = BytesIO()
-    metadata_csv.name = f"generated_min_metadata_for_{fasta_stream.name}.csv"
+    metadata_csv.name = generated_csv_name
     metadata_csv.write(f"Seq_ID,Owner_group,Shared_groups\n".encode('utf-8'))
-    for fasta_id in fasta_ids:
-        metadata_csv.write(f"{fasta_id},{owner_group},{','.join(shared_groups)}\n".encode('utf-8'))
+    for seq_id in seq_ids:
+        metadata_csv.write(f"{seq_id},{owner_group},{','.join(shared_groups)}\n".encode('utf-8'))
     logger.info("Uploading minimal metadata")
     add_metadata(metadata_csv, 'min')
 
@@ -240,7 +241,9 @@ def _post_fasta(sample_files, file_hash: FileHash):
 
 
 @logger_wraps()
-def add_fastq_submission(csv: BufferedReader):
+def add_fastq_submission(csv: BufferedReader,
+                         owner_group: str,
+                         shared_groups: Tuple[str]):
     usecols = [
         FASTQ_CSV_SAMPLE_ID,
         FASTQ_CSV_PATH_1,
@@ -252,11 +255,20 @@ def add_fastq_submission(csv: BufferedReader):
     if messages:
         raise FailedResponseException(messages)
 
+    # Handle minimal metadata creation if necessary
+    if owner_group is not None:
+        seq_ids = list(csv_dataframe[FASTQ_CSV_SAMPLE_ID])
+        min_csv_name = f"generated_min_metadata_for_{csv.name}.csv"
+        _create_minimal_metadata_records(seq_ids, min_csv_name, owner_group, shared_groups)
+
+    logger.info("Uploading sequences")
     for _, row in csv_dataframe.iterrows():
+        seq_id = row[FASTQ_CSV_SAMPLE_ID]
+        logger.info(f"Uploading {seq_id}")
         try:
             sample_files = []
             custom_headers = {
-                FASTQ_CSV_SAMPLE_ID_API: row[FASTQ_CSV_SAMPLE_ID],
+                FASTQ_CSV_SAMPLE_ID_API: seq_id,
                 FASTQ_CSV_PATH_1_API: os.path.basename(row[FASTQ_CSV_PATH_1]),
             }
             sample_files.append(_get_file(row[FASTQ_CSV_PATH_1]))
@@ -268,7 +280,7 @@ def add_fastq_submission(csv: BufferedReader):
             retry(lambda sf=sample_files, ch=custom_headers: _post_fastq(
                 sf, ch), 1, "/".join([SEQUENCE_PATH, FASTQ_PATH]))
         except FailedResponseException as ex:
-            logger.error(f'Sample {row[FASTQ_CSV_SAMPLE_ID]} failed upload')
+            logger.error(f'Sample {seq_id} failed upload')
             log_response(ex.parsed_resp)
         except (
                 PermissionError,
@@ -276,7 +288,7 @@ def add_fastq_submission(csv: BufferedReader):
                 HTTPStatusError,
                 IncorrectHashException,
         ) as ex:
-            logger.error(f'Sample {row[FASTQ_CSV_SAMPLE_ID]} failed upload')
+            logger.error(f'Sample {seq_id} failed upload')
             logger.error(ex)
         except Exception as ex:
             raise ex from ex

--- a/austrakka/utils/options.py
+++ b/austrakka/utils/options.py
@@ -470,23 +470,21 @@ def opt_group_role(**attrs: t.Any):
     )
 
 
-
 def opt_owner_group_for_record_creation():
-    defaults = {
-        'required': False,
-        'help': """Create new entries and set the owner for all records in the upload.
+    defaults = {'required': False, 'help':
+                """Create new entries and set the owner for all records in the upload.
 If this option is provided, new Seq_ID entries will be created for all
 provided sequences, with Owner_group set to this value. The effect is
 the same as as if `austrakka metadata add -p min` had been run.
 If any of the provided Seq_IDs already exist and have an Owner_group
-that differs from this value, this will result in an error. """
-    }
+that differs from this value, this will result in an error. """}
     return _create_option(
         '-O',
         '--owner-group',
         type=click.STRING,
         **defaults
     )
+
 
 def opt_shared_groups_for_record_creation():
     defaults = {
@@ -502,7 +500,7 @@ values set to the groups specified."""
         type=click.STRING,
         **defaults
     )
-        
+
 
 def _create_option(*param_decls: str, **attrs: t.Any):
     def inner_func(func):

--- a/austrakka/utils/options.py
+++ b/austrakka/utils/options.py
@@ -470,6 +470,40 @@ def opt_group_role(**attrs: t.Any):
     )
 
 
+
+def opt_owner_group_for_record_creation():
+    defaults = {
+        'required': False,
+        'help': """Create new entries and set the owner for all records in the upload.
+If this option is provided, new Seq_ID entries will be created for all
+provided sequences, with Owner_group set to this value. The effect is
+the same as as if `austrakka metadata add -p min` had been run.
+If any of the provided Seq_IDs already exist and have an Owner_group
+that differs from this value, this will result in an error. """
+    }
+    return _create_option(
+        '-O',
+        '--owner-group',
+        type=click.STRING,
+        **defaults
+    )
+
+def opt_shared_groups_for_record_creation():
+    defaults = {
+        'required': False,
+        'help': """Must be used in conjunction with --owner-group.
+If this option is provided, the new records created will have Shared_groups
+values set to the groups specified."""
+    }
+    return _create_option(
+        '-S',
+        '--shared-groups',
+        multiple=True,
+        type=click.STRING,
+        **defaults
+    )
+        
+
 def _create_option(*param_decls: str, **attrs: t.Any):
     def inner_func(func):
         return click.option(


### PR DESCRIPTION
Add --owner-group and --shared-groups options to austrakka seq add commands.
These are convenience options for the case where all uploaded sequences have the same ownership and sharing settings. These flags function like a pre-call to `austrakka metadata add -p min`. 

If owner group is not specified, the normal behaviour applies, i.e. no metadata records are created and records must already exist.
Shared groups may not be specified unless owner group is specified.
For now, owner group may also not be specified unless shared groups is specified; this is to minimise the risk of forgetting to share sequences. The use-case of deliberately uploading sequences without sharing them into any project is very rare and for now only accessible via a manual metadata upload.

WIP: based on feedback, will add interactive confirmation of Seq_IDs to be created, and a more stringent check on allowable Seq_ID patterns.