### PR TITLE
AB#4464 chunk metadata uploads

### DIFF
--- a/austrakka/components/metadata/__init__.py
+++ b/austrakka/components/metadata/__init__.py
@@ -16,25 +16,28 @@ from austrakka.components.metadata.funcs import append_metadata
 from austrakka.components.metadata.funcs import list_metadata, list_metadata_by_field
 from austrakka.utils.output import table_format_option
 
+ADD_APPEND_BATCH_SIZE_HELP = (
+    'The number of rows to split the metadata upload into before uploading. '
+    'If the file size is below this value, the file will not be split. '
+    'An upload record will be recorded in the database per batch, and '
+    'validation and success messages will be returned per batch. '
+    'Only CSV files will be batched; Excel files will be uploaded as one file. '
+    'A negative or 0 value can be used to indicate no batching.'
+)
+
 
 @click.group()
 @click.pass_context
 def metadata(ctx):
     """Commands related to metadata submissions"""
     ctx.context = ctx.parent.context
-
+    
 
 @metadata.command('add')
 @click.argument('file', type=click.File('rb'))
 @opt_proforma()
 @opt_blanks_delete()
-@opt_batch_size(help='The number of rows to split the metadata upload into before uploading. '
-                     'If the file size is below this value, the file will not be split. '
-                     'An upload record will be recorded in the database per batch, and '
-                     'validation and success messages will be returned per batch. '
-                     'Note that if an Excel file is batched, the only the submission '
-                     'worksheet will be uploaded. '
-                     'A negative or 0 value can be used to indicate no batching.',
+@opt_batch_size(help=ADD_APPEND_BATCH_SIZE_HELP,
                 default=5000)
 def submission_add(
         file: BufferedReader, 
@@ -49,12 +52,7 @@ def submission_add(
 @click.argument('file', type=click.File('rb'))
 @opt_proforma()
 @opt_blanks_delete()
-@opt_batch_size(help='The number of rows to split the metadata upload into before uploading. '
-                     'If the file size is below this value, the file will not be split. '
-                     'An upload record will be recorded in the database per batch, and '
-                     'validation and success messages will be returned per batch. '
-                     'Only CSV files will be batched; Excel files will be uploaded as one file. '
-                     'A negative or 0 value can be used to indicate no batching.',
+@opt_batch_size(help=ADD_APPEND_BATCH_SIZE_HELP,
                 default=5000)
 def submission_append(
         file: BufferedReader, 

--- a/austrakka/components/metadata/__init__.py
+++ b/austrakka/components/metadata/__init__.py
@@ -53,8 +53,7 @@ def submission_add(
                      'If the file size is below this value, the file will not be split. '
                      'An upload record will be recorded in the database per batch, and '
                      'validation and success messages will be returned per batch. '
-                     'Note that if an Excel file is batched, the only the submission '
-                     'worksheet will be uploaded.'
+                     'Only CSV files will be batched; Excel files will be uploaded as one file. '
                      'A negative or 0 value can be used to indicate no batching.',
                 default=5000)
 def submission_append(

--- a/austrakka/components/metadata/__init__.py
+++ b/austrakka/components/metadata/__init__.py
@@ -5,7 +5,7 @@ from typing import List
 from io import BufferedReader
 import click
 
-from austrakka.utils.options import opt_proforma
+from austrakka.utils.options import opt_proforma, opt_batch_size
 from austrakka.utils.options import opt_is_append
 from austrakka.utils.options import opt_group_name
 from austrakka.utils.options import opt_blanks_delete
@@ -28,33 +28,62 @@ def metadata(ctx):
 @click.argument('file', type=click.File('rb'))
 @opt_proforma()
 @opt_blanks_delete()
-def submission_add(file: BufferedReader, proforma: str, blanks_will_delete: bool = False):
+@opt_batch_size(help='The number of rows to split the metadata upload into before uploading. '
+                     'If the file size is below this value, the file will not be split. '
+                     'An upload record will be recorded in the database per batch, and '
+                     'validation and success messages will be returned per batch. '
+                     'Note that if an Excel file is batched, the only the submission '
+                     'worksheet will be uploaded. '
+                     'A negative or 0 value can be used to indicate no batching.',
+                default=5000)
+def submission_add(
+        file: BufferedReader, 
+        proforma: str, 
+        blanks_will_delete: bool,
+        batch_size: int):
     """Upload metadata submission to AusTrakka"""
-    add_metadata(file, proforma, blanks_will_delete)
+    add_metadata(file, proforma, blanks_will_delete, batch_size)
 
 
 @metadata.command('append')
 @click.argument('file', type=click.File('rb'))
 @opt_proforma()
 @opt_blanks_delete()
-def submission_append(file: BufferedReader, proforma: str, blanks_will_delete: bool = False):
+@opt_batch_size(help='The number of rows to split the metadata upload into before uploading. '
+                     'If the file size is below this value, the file will not be split. '
+                     'An upload record will be recorded in the database per batch, and '
+                     'validation and success messages will be returned per batch. '
+                     'Note that if an Excel file is batched, the only the submission '
+                     'worksheet will be uploaded.'
+                     'A negative or 0 value can be used to indicate no batching.',
+                default=5000)
+def submission_append(
+        file: BufferedReader, 
+        proforma: str, 
+        blanks_will_delete: bool,
+        batch_size: int):   
     """
     Upload metadata to be appended to existing samples.
     The append operation does not require (or accept) Owner_group.
     The specified pro forma must contain Seq_ID and metadata fields
     to be updated. All samples must already exist in AusTrakka.
     """
-    append_metadata(file, proforma, blanks_will_delete)
+    append_metadata(file, proforma, blanks_will_delete, batch_size)
 
 
 @metadata.command('validate')
 @click.argument('file', type=click.File('rb'))
 @opt_proforma()
 @opt_is_append()
-def submission_validate(file: BufferedReader, proforma: str, is_append: bool):
+@opt_batch_size(help='The number of rows to split the metadata upload into before uploading. '
+                     'If the file size is below this value, the file will not be split. '
+                     'Validation messages will be returned per batch.'
+                     'A negative or 0 value can be used to indicate no batching.',
+                default=5000)
+def submission_validate(file: BufferedReader, proforma: str, is_append: bool, batch_size: int):
     """Check uploaded content for errors and warnings. This is a read-only
     action. No data will modified."""
-    validate_metadata(file, proforma, is_append)
+    validate_metadata(file, proforma, is_append, batch_size)
 
 
 @metadata.command('list')

--- a/austrakka/components/metadata/funcs.py
+++ b/austrakka/components/metadata/funcs.py
@@ -1,6 +1,11 @@
 from typing import List
 
-from io import BufferedReader
+from loguru import logger
+
+from pathlib import Path
+from io import BufferedReader, StringIO
+import codecs
+import pandas as pd
 
 from austrakka.utils.misc import logger_wraps
 from austrakka.utils.api import api_post_multipart
@@ -19,37 +24,78 @@ METADATA_BY_FIELD_PATH = 'by-field'
 
 @logger_wraps()
 def add_metadata(
-    file: BufferedReader,
-    proforma_abbrev: str,
+        file: BufferedReader,
+        proforma_abbrev: str,
         blanks_will_delete: bool,
+        batch_size: int,
 ):
     path = "/".join([SUBMISSION_PATH, SUBMISSION_UPLOAD])
     if blanks_will_delete:
         path = f"{path}?{DELETE_ON_BLANK_PARAM}"
-    _call_submission(path, file, proforma_abbrev)
+    _call_batched_submission(path, file, proforma_abbrev, batch_size)
 
 
 @logger_wraps()
 def append_metadata(
-    file: BufferedReader,
-    proforma_abbrev: str,
+        file: BufferedReader,
+        proforma_abbrev: str,
         blanks_will_delete: bool,
+        batch_size: int,
 ):
     path = "/".join([SUBMISSION_PATH, SUBMISSION_UPLOAD_APPEND])
     if blanks_will_delete:
         path = f"{path}&{DELETE_ON_BLANK_PARAM}"
-    _call_submission(path, file, proforma_abbrev)
+    _call_batched_submission(path, file, proforma_abbrev, batch_size)
 
 
 @logger_wraps()
 def validate_metadata(
-    file: BufferedReader,
-    proforma_abbrev: str,
-    is_append: bool
+        file: BufferedReader,
+        proforma_abbrev: str,
+        is_append: bool,
+        batch_size: int,
 ):
     path = SUBMISSION_VALIDATE_APPEND if is_append else SUBMISSION_VALIDATE
     path = "/".join([SUBMISSION_PATH, path])
-    _call_submission(path, file, proforma_abbrev)
+    _call_batched_submission(path, file, proforma_abbrev, batch_size)
+
+
+def _call_batched_submission(
+        path: str,
+        file: BufferedReader,
+        proforma_abbrev: str,
+        batch_size: int
+):
+    filepath = Path(file.name)
+    if  filepath.suffix == '.csv':
+        df = pd.read_csv(file, dtype=str, index_col=False, keep_default_na=False, na_values='')
+    elif filepath.suffix == '.xlsx':
+        # will read the first worksheet
+        df = pd.read_excel(file, dtype=str, index_col=False, keep_default_na=False, na_values='')
+    else:
+        raise ValueError('File must be .csv or .xlsx')
+    
+    num_rows = df.shape[0]
+    if num_rows <= batch_size:
+        # Just upload the original file
+        file.seek(0)
+        _call_submission(path, file, proforma_abbrev)
+        return
+    
+    logger.info(f"Uploading {num_rows} rows in batches of {batch_size}")
+    encode = codecs.getwriter('utf-8')
+    if filepath.suffix == '.xlsx':
+        logger.info("XLSX file will be uploaded as CSV batches and only the first worksheet "
+                    "will be used")
+    for index in range(0, num_rows, batch_size):
+        logger.info(f"Uploading rows {index}-{index+batch_size-1}")
+        chunk = df.iloc[index:index+batch_size, :]
+        buffer = StringIO()
+        buffer.name = f"{filepath.stem}_batch_rows{index}-{index+batch_size-1}.csv"
+        chunk.to_csv(buffer, index=False)
+        _call_submission(path, encode(buffer), proforma_abbrev)
+    
+    logger.info("Batched upload complete")
 
 
 def _call_submission(

--- a/austrakka/components/metadata/funcs.py
+++ b/austrakka/components/metadata/funcs.py
@@ -57,7 +57,10 @@ def validate_metadata(
 ):
     path = SUBMISSION_VALIDATE_APPEND if is_append else SUBMISSION_VALIDATE
     path = "/".join([SUBMISSION_PATH, path])
-    _call_batched_submission(path, file, proforma_abbrev, batch_size)
+    if batch_size > 0:
+        _call_batched_submission(path, file, proforma_abbrev, batch_size)
+    else:
+        _call_submission(path, file, proforma_abbrev)
 
 
 def _call_batched_submission(

--- a/austrakka/components/metadata/funcs.py
+++ b/austrakka/components/metadata/funcs.py
@@ -57,11 +57,8 @@ def validate_metadata(
 ):
     path = SUBMISSION_VALIDATE_APPEND if is_append else SUBMISSION_VALIDATE
     path = "/".join([SUBMISSION_PATH, path])
-    if batch_size > 0:
-        _call_batched_submission(path, file, proforma_abbrev, batch_size)
-    else:
-        _call_submission(path, file, proforma_abbrev)
-
+    _call_batched_submission(path, file, proforma_abbrev, batch_size)
+    
 
 def _call_batched_submission(
         path: str,
@@ -69,6 +66,10 @@ def _call_batched_submission(
         proforma_abbrev: str,
         batch_size: int
 ):
+    if batch_size < 1:
+        _call_submission(path, file, proforma_abbrev)
+        return
+    
     filepath = Path(file.name)
     if  filepath.suffix == '.csv':
         # pylint: disable=C0103

--- a/austrakka/components/metadata/funcs.py
+++ b/austrakka/components/metadata/funcs.py
@@ -70,8 +70,9 @@ def _call_batched_submission(
     if  filepath.suffix == '.csv':
         df = pd.read_csv(file, dtype=str, index_col=False, keep_default_na=False, na_values='')
     elif filepath.suffix == '.xlsx':
-        # will read the first worksheet
-        df = pd.read_excel(file, dtype=str, index_col=False, keep_default_na=False, na_values='')
+        # Batching not currently supported, just upload the original file
+        _call_submission(path, file, proforma_abbrev)
+        return
     else:
         raise ValueError('File must be .csv or .xlsx')
     
@@ -84,9 +85,6 @@ def _call_batched_submission(
     
     logger.info(f"Uploading {num_rows} rows in batches of {batch_size}")
     encode = codecs.getwriter('utf-8')
-    if filepath.suffix == '.xlsx':
-        logger.info("XLSX file will be uploaded as CSV batches and only the first worksheet "
-                    "will be used")
     for index in range(0, num_rows, batch_size):
         logger.info(f"Uploading rows {index}-{index+batch_size-1}")
         chunk = df.iloc[index:index+batch_size, :]

--- a/austrakka/components/metadata/funcs.py
+++ b/austrakka/components/metadata/funcs.py
@@ -1,10 +1,10 @@
 from typing import List
 
-from loguru import logger
-
 from pathlib import Path
 from io import BufferedReader, StringIO
 import codecs
+
+from loguru import logger
 import pandas as pd
 
 from austrakka.utils.misc import logger_wraps
@@ -71,6 +71,7 @@ def _call_batched_submission(
 ):
     filepath = Path(file.name)
     if  filepath.suffix == '.csv':
+        # pylint: disable=C0103
         df = pd.read_csv(file, dtype=str, index_col=False, keep_default_na=False, na_values='')
     elif filepath.suffix == '.xlsx':
         # Batching not currently supported, just upload the original file

--- a/austrakka/components/sequence/sync/__init__.py
+++ b/austrakka/components/sequence/sync/__init__.py
@@ -5,7 +5,7 @@ from austrakka.utils.options import opt_output_dir
 from austrakka.utils.options import opt_group
 from austrakka.utils.options import opt_recalc_hash
 from austrakka.utils.options import opt_seq_type
-from austrakka.utils.options import opt_download_batch_size
+from austrakka.utils.options import opt_batch_size
 from .funcs import seq_get
 
 
@@ -21,7 +21,15 @@ def sync(ctx):
 @opt_group(default=None, multiple=False, required=True)
 @opt_recalc_hash()
 @opt_seq_type(required=True)
-@opt_download_batch_size()
+@opt_batch_size(help='Specifies the number of sequence downloads to perform '
+                     'in a single batch during sync. This may improve '
+                     'performance depending on how many total sequences are expected. '
+                     'When resuming from an interruption, the '
+                     'entire batch will be re-tried even if some within a '
+                     'batch might have succeeded. For large fastq files, the '
+                     'recommended size is 1 to 10. For large numbers of small '
+                     'fasta files, the recommended size is 1000 or more.',
+                default=1)
 @option('--reset', help="Reset sync state; do not try to resume an "
                         "interrupted sync", is_flag=True)
 def get_seq(

--- a/austrakka/utils/options.py
+++ b/austrakka/utils/options.py
@@ -391,23 +391,15 @@ def opt_user_object_id(**attrs: t.Any):
     )
 
 
-def opt_download_batch_size(**attrs: t.Any):
+def opt_batch_size(**attrs: t.Any):
     defaults = {
         'required': False,
-        'help': 'Specifies the number of sequence downloads to perform '
-                'in a single batch during sync. This could improve '
-                'performance depending on how many total sequences are expected. '
-                'When resuming from an interruption, the '
-                'entire batch would be re-tried even if some within a '
-                'batch might have succeeded. For large fastq files, the '
-                'recommended size is 1 to 10. For large numbers of small '
-                'fasta files, the recommended size is 1000. Default is 1.',
+        'help': 'Batch size for upload/download'
     }
     return _create_option(
         '-bs',
         '--batch-size',
         type=click.INT,
-        default=1,
         **{**defaults, **attrs}
     )
 
@@ -556,5 +548,6 @@ def _create_option(*param_decls: str, **attrs: t.Any):
         return click.option(
             *param_decls,
             cls=AusTrakkaCliOption,
+            show_default=True,
             **attrs)(func)
     return inner_func


### PR DESCRIPTION
Split large CSV files into chunks for upload or validation.

Currently only supports CSV files; Excel support will be present if commit https://github.com/AusTrakka/austrakka2-cli/commit/e58f9bcd7ae7e2d3472d55d1d7a33804e4250fa9 is reverted, but will need to deal with what I assume is this bug: https://foss.heptapod.net/openpyxl/openpyxl/-/issues/1963

