### PR TITLE
4497 attaching files to proformas

### DIFF
--- a/austrakka/components/proforma/__init__.py
+++ b/austrakka/components/proforma/__init__.py
@@ -106,7 +106,17 @@ def proforma_attach(abbrev: str,
                     file_path: str = None,
                     proforma_version: int = None):
     """
-    This will attach a file to the ProForma Version that you specify.
+    This command will attach a file or pull a existing file to latest ProForma Version
+
+    Usage:
+
+    austrakka proforma attach [ABBREV] ~~This will pull the file from the last proforma version
+
+    austrakka proforma attach [ABBREV] -f [FILEPATH] ~~attaches given file
+
+    austrakka proforma attach [ABBREV] -id [PROFORMA-VERSION-ID] ~~this pulls a file from specified id
+
+    ABBREV should be the abbreviated name of the pro forma.
     """
     if file_path is None:
         pull_proforma(abbrev, proforma_version)

--- a/austrakka/components/proforma/__init__.py
+++ b/austrakka/components/proforma/__init__.py
@@ -1,4 +1,3 @@
-from io import BufferedReader
 from typing import List
 
 from austrakka.utils.output import table_format_option
@@ -114,7 +113,8 @@ def proforma_attach(abbrev: str,
 
     austrakka proforma attach [ABBREV] -f [FILEPATH] ~~attaches given file
 
-    austrakka proforma attach [ABBREV] -id [PROFORMA-VERSION-ID] ~~this pulls a file from specified id
+    austrakka proforma attach [ABBREV] -id [PROFORMA-VERSION-ID]
+    ~~this pulls a file from specified id
 
     ABBREV should be the abbreviated name of the pro forma.
     """

--- a/austrakka/components/proforma/__init__.py
+++ b/austrakka/components/proforma/__init__.py
@@ -1,3 +1,4 @@
+from io import BufferedReader
 from typing import List
 
 from austrakka.utils.output import table_format_option
@@ -11,7 +12,7 @@ from .funcs import \
     enable_proforma, \
     share_proforma, \
     unshare_proforma, \
-    list_groups_proforma
+    list_groups_proforma, attach_proforma, pull_proforma
 
 from ...utils.options import *
 
@@ -84,6 +85,33 @@ def proforma_update(
         abbrev,
         required_field,
         optional_field)
+
+
+@proforma.command('attach', hidden=hide_admin_cmds())
+@click.argument('abbrev', type=click.STRING)
+@click.option('-f',
+              '--file-path',
+              help='File that you may want to link.  '
+                   'Only one xlsx filepath will be accepted',
+              cls=MutuallyExclusiveOption,
+              mutually_exclusive=["proforma-version"])
+@click.option('-v',
+              '--proforma-version',
+              cls=MutuallyExclusiveOption,
+              help="If pulling a file from previous proforma "
+                   "you can specify a specific proforma version",
+              type=click.INT,
+              mutually_exclusive=["file-path"])
+def proforma_attach(abbrev: str,
+                    file_path: str = None,
+                    proforma_version: int = None):
+    """
+    This will attach a file to the ProForma Version that you specify.
+    """
+    if file_path is None:
+        pull_proforma(abbrev, proforma_version)
+    else:
+        attach_proforma(abbrev, file_path)
 
 
 @proforma.command('list')

--- a/austrakka/components/proforma/funcs.py
+++ b/austrakka/components/proforma/funcs.py
@@ -16,7 +16,7 @@ from austrakka.utils.output import print_table, log_response
 from austrakka.utils.helpers.fields import get_system_field_names
 from austrakka.utils.paths import PROFORMA_PATH
 from austrakka.utils.retry import retry
-from austrakka.utils.fs import FileHash, verify_hash
+from austrakka.utils.fs import FileHash, verify_hash, verify_hash_single
 
 ATTACH = 'Attach'
 
@@ -310,4 +310,4 @@ def _post_proforma(files, file_hash: FileHash, custom_headers: dict):
     data = get_response(resp, True)
     print(resp.status_code)
     if resp.status_code == 200:
-        verify_hash(list([file_hash]), data)
+        verify_hash_single(file_hash, data)

--- a/austrakka/components/proforma/funcs.py
+++ b/austrakka/components/proforma/funcs.py
@@ -1,3 +1,4 @@
+import os
 from typing import List
 import hashlib
 import pandas as pd
@@ -158,25 +159,25 @@ def attach_proforma(abbrev: str,
     with open(filepath, 'rb') as file_content:
         files = [('files[]', (filepath, file_content))]
 
-    custom_headers = {
-        'proforma-abbrev': abbrev,
-        'filename': filepath,
-    }
-    try:
-        retry(
-            func=lambda f=files, fh=file_hash, ch=custom_headers: _post_proforma(f, fh, ch),
-            retries=0,
-            desc=f"{abbrev} at " + "/".join([PROFORMA_PATH, ATTACH]),
-            delay=0.0
-        )
-    except FailedResponseException as ex:
-        logger.error(f'Pro Forma {abbrev} failed upload')
-        log_response(ex.parsed_resp)
-    except (
-            PermissionError, UnknownResponseException, HTTPStatusError
-    ) as ex:
-        logger.error(f'Pro Forma {abbrev} failed upload')
-        logger.error(ex)
+        custom_headers = {
+            'proforma-abbrev': abbrev,
+            'filename': os.path.basename(filepath),
+        }
+        try:
+            retry(
+                func=lambda f=files, fh=file_hash, ch=custom_headers: _post_proforma(f, fh, ch),
+                retries=0,
+                desc=f"{abbrev} at " + "/".join([PROFORMA_PATH, ATTACH]),
+                delay=0.0
+            )
+        except FailedResponseException as ex:
+            logger.error(f'Pro Forma {abbrev} failed upload')
+            log_response(ex.parsed_resp)
+        except (
+                PermissionError, UnknownResponseException, HTTPStatusError
+        ) as ex:
+            logger.error(f'Pro Forma {abbrev} failed upload')
+            logger.error(ex)
 
 
 @logger_wraps()
@@ -279,7 +280,7 @@ def list_groups_proforma(abbrev: str, out_format: str):
 def _proforma_hash(filepath):
     with open(filepath, 'rb') as file:
         return FileHash(
-            filename=filepath,
+            filename=os.path.basename(filepath),
             sha256=hashlib.sha256(file.read()).hexdigest())
 
 

--- a/austrakka/components/proforma/funcs.py
+++ b/austrakka/components/proforma/funcs.py
@@ -181,31 +181,14 @@ def attach_proforma(abbrev: str,
 
 @logger_wraps()
 def pull_proforma(abbrev: str,
-                    version: int):
-    pass
-    """
-    abbrev: 
-    file:
-    
-    file_hash = _proforma_hash(filepath)
-    file_content = open(filepath, 'rb')
-    files = [('files[]', (filepath, file_content))]
-    try:
-        retry(
-            func=lambda f=files, fh=file_hash, ch={"abbrev": abbrev}: _post_proforma(f, fh, ch),
-            retries=0,
-            desc=f"{abbrev} at " + "/".join([PROFORMA_PATH, ATTACH]),
-            delay=0.0
-        )
-    except FailedResponseException as ex:
-        logger.error(f'Pro Forma {abbrev} failed upload')
-        log_response(ex.parsed_resp)
-    except (
-            PermissionError, UnknownResponseException, HTTPStatusError
-    ) as ex:
-        logger.error(f'Pro Forma {abbrev} failed upload')
-        logger.error(ex)
-"""
+                  version: int = None):
+    if version is None:
+        print('got here')
+        api_patch(path=f'{PROFORMA_PATH}/PullPrevious/{abbrev}')
+    else:
+        api_patch(path=f'{PROFORMA_PATH}/PullPrevious/{abbrev}/{version}')
+
+    logger.info('Done')
 
 @logger_wraps()
 def list_proformas(out_format: str):
@@ -306,8 +289,6 @@ def _post_proforma(files, file_hash: FileHash, custom_headers: dict):
         files=files,
         custom_headers=custom_headers,
     )
-    print("hei")
     data = get_response(resp, True)
-    print(resp.status_code)
     if resp.status_code == 200:
         verify_hash_single(file_hash, data)

--- a/austrakka/components/proforma/funcs.py
+++ b/austrakka/components/proforma/funcs.py
@@ -1,17 +1,24 @@
+from io import BufferedReader
 from typing import List
 
 import pandas as pd
+from httpx import HTTPStatusError
 from loguru import logger
+import hashlib
 
-from austrakka.utils.api import api_get
+from austrakka.utils.api import api_get, api_post_multipart_raw, get_response
 from austrakka.utils.api import api_post
 from austrakka.utils.api import api_patch
 from austrakka.utils.api import api_put
+from austrakka.utils.exceptions import FailedResponseException, UnknownResponseException
 from austrakka.utils.misc import logger_wraps
-from austrakka.utils.output import print_table
+from austrakka.utils.output import print_table, log_response
 from austrakka.utils.helpers.fields import get_system_field_names
 from austrakka.utils.paths import PROFORMA_PATH
+from austrakka.utils.retry import retry
+from austrakka.utils.fs import FileHash, verify_hash
 
+ATTACH = 'Attach'
 
 @logger_wraps()
 def disable_proforma(abbrev: str):
@@ -141,6 +148,66 @@ def add_proforma(
 
 
 @logger_wraps()
+def attach_proforma(abbrev: str,
+                    filepath: str):
+    """
+    abbrev: 
+    file:
+    """
+    file_hash = _proforma_hash(filepath)
+    file_content = open(filepath, 'rb')
+    files = [('files[]', (filepath, file_content))]
+
+    custom_headers = {
+        'proforma-abbrev': abbrev,
+        'filename': filepath,
+    }
+    try:
+        retry(
+            func=lambda f=files, fh=file_hash, ch=custom_headers: _post_proforma(f, fh, ch),
+            retries=0,
+            desc=f"{abbrev} at " + "/".join([PROFORMA_PATH, ATTACH]),
+            delay=0.0
+        )
+    except FailedResponseException as ex:
+        logger.error(f'Pro Forma {abbrev} failed upload')
+        log_response(ex.parsed_resp)
+    except (
+            PermissionError, UnknownResponseException, HTTPStatusError
+    ) as ex:
+        logger.error(f'Pro Forma {abbrev} failed upload')
+        logger.error(ex)
+
+
+@logger_wraps()
+def pull_proforma(abbrev: str,
+                    version: int):
+    pass
+    """
+    abbrev: 
+    file:
+    
+    file_hash = _proforma_hash(filepath)
+    file_content = open(filepath, 'rb')
+    files = [('files[]', (filepath, file_content))]
+    try:
+        retry(
+            func=lambda f=files, fh=file_hash, ch={"abbrev": abbrev}: _post_proforma(f, fh, ch),
+            retries=0,
+            desc=f"{abbrev} at " + "/".join([PROFORMA_PATH, ATTACH]),
+            delay=0.0
+        )
+    except FailedResponseException as ex:
+        logger.error(f'Pro Forma {abbrev} failed upload')
+        log_response(ex.parsed_resp)
+    except (
+            PermissionError, UnknownResponseException, HTTPStatusError
+    ) as ex:
+        logger.error(f'Pro Forma {abbrev} failed upload')
+        logger.error(ex)
+"""
+
+@logger_wraps()
 def list_proformas(out_format: str):
     response = api_get(
         path=PROFORMA_PATH,
@@ -224,3 +291,23 @@ def list_groups_proforma(abbrev: str, out_format: str):
         result,
         out_format,
     )
+
+
+def _proforma_hash(filepath):
+    file = open(filepath, 'rb')
+    return FileHash(
+        filename=filepath,
+        sha256=hashlib.sha256(file.read()).hexdigest())
+
+
+def _post_proforma(files, file_hash: FileHash, custom_headers: dict):
+    resp = api_post_multipart_raw(
+        path="/".join([PROFORMA_PATH, ATTACH]),
+        files=files,
+        custom_headers=custom_headers,
+    )
+    print("hei")
+    data = get_response(resp, True)
+    print(resp.status_code)
+    if resp.status_code == 200:
+        verify_hash(list([file_hash]), data)

--- a/austrakka/components/sequence/funcs.py
+++ b/austrakka/components/sequence/funcs.py
@@ -39,6 +39,7 @@ from austrakka.utils.enums.seq import UPLOAD_MODE_OVERWRITE
 from austrakka.utils.output import print_table
 from austrakka.utils.retry import retry
 from austrakka.utils.api import api_delete
+from austrakka.utils.fs import FileHash, verify_hash
 
 FASTA_PATH = 'Fasta'
 FASTQ_PATH = 'Fastq'
@@ -65,13 +66,6 @@ class SeqFile:
     multipart: tuple
     sha256: str
     filename: str
-
-
-@dataclass
-class FileHash:
-    filename: str
-    sha256: str
-
 
 @logger_wraps()
 def add_fasta_submission(
@@ -198,20 +192,7 @@ def _post_fastq(sample_files: list[SeqFile], custom_headers):
     if resp.status_code == 200:
         hashes = [FileHash(filename=f.filename, sha256=f.sha256)
                   for f in sample_files]
-        _verify_hash(hashes, data)
-
-
-def _verify_hash(hashes: list[FileHash], resp: dict):
-    errors = []
-    for seq in resp['data']:
-        if not any(
-                f.filename == seq['originalFileName']
-                and f.sha256.casefold() == seq['serverSha256'].casefold()
-                for f in hashes
-        ):
-            errors.append(f'Hash for {seq["originalFileName"]} is not correct')
-    if any(errors):
-        raise IncorrectHashException(", ".join(errors))
+        verify_hash(hashes, data)
 
 
 def _post_fasta(sample_files, file_hash: FileHash, custom_headers: dict):
@@ -223,7 +204,7 @@ def _post_fasta(sample_files, file_hash: FileHash, custom_headers: dict):
 
     data = get_response(resp, True)
     if resp.status_code == 200:
-        _verify_hash(list([file_hash]), data)
+        verify_hash(list([file_hash]), data)
 
 
 @logger_wraps()

--- a/austrakka/utils/fs.py
+++ b/austrakka/utils/fs.py
@@ -22,13 +22,13 @@ def create_dir(output_dir):
 
 def verify_hash(hashes: list[FileHash], resp: dict):
     errors = []
-    for uploadDto in resp['data']:
+    for upload_dto in resp['data']:
         if not any(
-                f.filename == uploadDto['originalFileName']
-                and f.sha256.casefold() == uploadDto['serverSha256'].casefold()
+                f.filename == upload_dto['originalFileName']
+                and f.sha256.casefold() == upload_dto['serverSha256'].casefold()
                 for f in hashes
         ):
-            errors.append(f'Hash for {uploadDto["originalFileName"]} is not correct')
+            errors.append(f'Hash for {upload_dto["originalFileName"]} is not correct')
     if any(errors):
         raise IncorrectHashException(", ".join(errors))
 
@@ -41,7 +41,7 @@ def verify_hash_single(a_hash: FileHash, resp: dict):
             a_hash.filename == upload_dto['originalFileName'] and
             a_hash.sha256.casefold() == upload_dto['serverSha256'].casefold()
     ):
-        errors = f'Hash for {upload_dto["originalFileName"]} is not correct'
+        error = f'Hash for {upload_dto["originalFileName"]} is not correct'
 
     if error != '':
         raise IncorrectHashException(error)

--- a/austrakka/utils/fs.py
+++ b/austrakka/utils/fs.py
@@ -34,14 +34,14 @@ def verify_hash(hashes: list[FileHash], resp: dict):
 
 
 def verify_hash_single(a_hash: FileHash, resp: dict):
-    errors = []
+    error = ''
     upload_dto = resp['data']
 
     if not (
             a_hash.filename == upload_dto['originalFileName'] and
             a_hash.sha256.casefold() == upload_dto['serverSha256'].casefold()
     ):
-        errors.append(f'Hash for {upload_dto["originalFileName"]} is not correct')
+        errors = f'Hash for {upload_dto["originalFileName"]} is not correct'
 
-    if any(errors):
-        raise IncorrectHashException(", ".join(errors))
+    if error != '':
+        raise IncorrectHashException(error)

--- a/austrakka/utils/fs.py
+++ b/austrakka/utils/fs.py
@@ -1,4 +1,13 @@
 import os
+from dataclasses import dataclass
+
+from austrakka.utils.exceptions import IncorrectHashException
+
+
+@dataclass
+class FileHash:
+    filename: str
+    sha256: str
 
 
 def create_dir(output_dir):
@@ -9,3 +18,30 @@ def create_dir(output_dir):
     except PermissionError as ex:
         raise ValueError(
             f'Write permission denied for given output directory {output_dir}') from ex
+
+
+def verify_hash(hashes: list[FileHash], resp: dict):
+    errors = []
+    for uploadDto in resp['data']:
+        if not any(
+                f.filename == uploadDto['originalFileName']
+                and f.sha256.casefold() == uploadDto['serverSha256'].casefold()
+                for f in hashes
+        ):
+            errors.append(f'Hash for {uploadDto["originalFileName"]} is not correct')
+    if any(errors):
+        raise IncorrectHashException(", ".join(errors))
+
+
+def verify_hash_single(a_hash: FileHash, resp: dict):
+    errors = []
+    upload_dto = resp['data']
+
+    if not (
+            a_hash.filename == upload_dto['originalFileName'] and
+            a_hash.sha256.casefold() == upload_dto['serverSha256'].casefold()
+    ):
+        errors.append(f'Hash for {upload_dto["originalFileName"]} is not correct')
+
+    if any(errors):
+        raise IncorrectHashException(", ".join(errors))


### PR DESCRIPTION
Implemented the command for attaching files that calls the related endpoints.

When a user creates or updates a proforma a new ProForma Version Record is made which does not have an associated file attached to it (linked). This command allows the user to attach or pull a file from a previous ProForma Version.

austrakka proforma attach [ABBREV] ~~ attaches a file from the previous proforma version
austrakka proforma attach [ABBREV] -f [FILEPATH] ~~attaches file given in the file path
austrakka proforma attach [ABBREV] -v [PROFORMA-VERSION-ID] ~~ which pulls from a specified id instead of the previous.

