### PR TITLE
4710 allow download of sequences by seqids

### DIFF
--- a/austrakka/components/proforma/__init__.py
+++ b/austrakka/components/proforma/__init__.py
@@ -184,7 +184,7 @@ def proforma_enable(abbrev: str):
 
 @proforma.command('share', hidden=hide_admin_cmds())
 @click.argument('abbrev', type=click.STRING)
-@opt_groups()
+@opt_group_name(var_name='group_names', multiple=True)
 def proforma_share(abbrev: str, group_names: List[str]):
     """
     Share a pro forma with one or more groups so can see the proforma
@@ -200,7 +200,7 @@ def proforma_share(abbrev: str, group_names: List[str]):
 
 @proforma.command('unshare', hidden=hide_admin_cmds())
 @click.argument('abbrev', type=click.STRING)
-@opt_groups()
+@opt_group_name(var_name='group_names', multiple=True)
 def proforma_unshare(abbrev: str, group_names: List[str]):
     """
     UnShare a pro forma with one or more groups to prevent the proforma

--- a/austrakka/components/sequence/__init__.py
+++ b/austrakka/components/sequence/__init__.py
@@ -39,10 +39,11 @@ seq.add_command(sync)
 @opt_output_dir()
 @opt_seq_type()
 @opt_read()
-@opt_group(default=None,
-           multiple=False,
-           cls=RequiredMutuallyExclusiveOption,
-           mutually_exclusive=['sample_id'])
+@opt_group(
+    default=None,
+    multiple=False,
+    cls=RequiredMutuallyExclusiveOption,
+    mutually_exclusive=['sample_id'])
 @opt_sample_id(
     default=None,
     help='The Seq_IDs of specific sequences to download',

--- a/austrakka/components/sequence/__init__.py
+++ b/austrakka/components/sequence/__init__.py
@@ -1,7 +1,10 @@
 # pylint: disable=redefined-outer-name
+from typing import List
+
 import click
 
 from austrakka.utils.output import table_format_option
+from austrakka.utils.options import RequiredMutuallyExclusiveOption
 from austrakka.utils.options import opt_output_dir
 from austrakka.utils.options import opt_read
 from austrakka.utils.options import opt_group
@@ -18,7 +21,7 @@ from .add import add
 from .sync import sync
 
 
-BY_SAMPLE = 'by-sample'
+
 
 
 @click.group()
@@ -35,12 +38,23 @@ seq.add_command(sync)
 @seq.command('get')
 @opt_output_dir()
 @opt_read()
-@opt_group(default=None, multiple=False, required=True)
+@opt_group(default=None,
+           multiple=False,
+           required=True,
+           cls=RequiredMutuallyExclusiveOption,
+           mutually_exclusive=['sample_id'])
+@opt_sample_id(
+    default=None,
+    help='The Seq_IDs of specific sequences to download',
+    cls= RequiredMutuallyExclusiveOption,
+    mutually_exclusive= ['group_name']
+)
 def get(
         output_dir,
         seq_type: str,
         read: str,
-        group_name: str,
+        group_name: str = None,
+        sample_id: List[str] = None,
 ):
     """Download sequence files to the local drive
 
@@ -55,6 +69,7 @@ def get(
         seq_type,
         read,
         group_name,
+        sample_id,
     )
 
 

--- a/austrakka/components/sequence/__init__.py
+++ b/austrakka/components/sequence/__init__.py
@@ -40,11 +40,13 @@ seq.add_command(sync)
 @opt_seq_type()
 @opt_read()
 @opt_group(
+    required=False,
     default=None,
     multiple=False,
     cls=RequiredMutuallyExclusiveOption,
     mutually_exclusive=['sample_id'])
 @opt_sample_id(
+    requird=False,
     default=None,
     help='The Seq_IDs of specific sequences to download',
     cls=RequiredMutuallyExclusiveOption,

--- a/austrakka/components/sequence/__init__.py
+++ b/austrakka/components/sequence/__init__.py
@@ -4,7 +4,7 @@ from typing import List
 import click
 
 from austrakka.utils.output import table_format_option
-from austrakka.utils.options import RequiredMutuallyExclusiveOption
+from austrakka.utils.options import RequiredMutuallyExclusiveOption, opt_seq_type
 from austrakka.utils.options import opt_output_dir
 from austrakka.utils.options import opt_read
 from austrakka.utils.options import opt_group
@@ -37,24 +37,23 @@ seq.add_command(sync)
 
 @seq.command('get')
 @opt_output_dir()
+@opt_seq_type()
 @opt_read()
 @opt_group(default=None,
            multiple=False,
-           required=True,
            cls=RequiredMutuallyExclusiveOption,
            mutually_exclusive=['sample_id'])
 @opt_sample_id(
     default=None,
     help='The Seq_IDs of specific sequences to download',
-    cls= RequiredMutuallyExclusiveOption,
-    mutually_exclusive= ['group_name']
-)
+    cls=RequiredMutuallyExclusiveOption,
+    mutually_exclusive=['group_name'])
 def get(
         output_dir,
         seq_type: str,
         read: str,
-        group_name: str = None,
-        sample_id: List[str] = None,
+        group_name: str,
+        sample_id: List[str],
 ):
     """Download sequence files to the local drive
 

--- a/austrakka/components/sequence/__init__.py
+++ b/austrakka/components/sequence/__init__.py
@@ -4,10 +4,9 @@ from typing import List
 import click
 
 from austrakka.utils.output import table_format_option
-from austrakka.utils.options import RequiredMutuallyExclusiveOption, opt_seq_type
+from austrakka.utils.options import RequiredMutuallyExclusiveOption, opt_seq_type, opt_group_name
 from austrakka.utils.options import opt_output_dir
 from austrakka.utils.options import opt_read
-from austrakka.utils.options import opt_group
 from austrakka.utils.options import opt_sample_id
 from austrakka.utils.options import opt_force_mutex_skip
 from austrakka.utils.options import opt_skip_mutex_force
@@ -39,14 +38,14 @@ seq.add_command(sync)
 @opt_output_dir()
 @opt_seq_type()
 @opt_read()
-@opt_group(
+@opt_group_name(
     required=False,
     default=None,
     multiple=False,
     cls=RequiredMutuallyExclusiveOption,
     mutually_exclusive=['sample_id'])
 @opt_sample_id(
-    requird=False,
+    required=False,
     default=None,
     help='The Seq_IDs of specific sequences to download',
     cls=RequiredMutuallyExclusiveOption,
@@ -79,7 +78,7 @@ def get(
 @table_format_option()
 @opt_seq_type(default=None, required=False)
 @opt_read()
-@opt_group(default=None, multiple=False, required=True)
+@opt_group_name(default=None, multiple=False, required=True)
 def seq_list(
         out_format: str,
         seq_type: str,

--- a/austrakka/components/sequence/funcs.py
+++ b/austrakka/components/sequence/funcs.py
@@ -400,9 +400,10 @@ def _get_seq_api_sample_names(sample_ids: List[str]):
     api_path = SEQUENCE_PATH
     paths = []
     if sample_ids is not None:
-        for id in sample_ids:
-            api_path += f'/{SEQUENCE_BY_SAMPLE_PATH}/{id}'
+        for sample in sample_ids:
+            api_path += f'/{SEQUENCE_BY_SAMPLE_PATH}/{sample}'
             paths.append(api_path)
+            api_path = SEQUENCE_PATH
     else:
         raise ValueError("A filter has not been passed")
     return paths
@@ -413,16 +414,16 @@ def _get_seq_data(
         seq_type: str,
         read: str,
         group_name: str,
-        sample_ids: List[str],
+        sample_ids: List[str] = None,
 ):
     data = []
-    if group_name == None:
+    if group_name is not None:
         api_path = _get_seq_api(group_name)
         data = api_get(path=api_path)['data']
     else:
         api_paths = _get_seq_api_sample_names(sample_ids)
-        for p in api_paths:
-            data.extend(api_get(path=p)['data'])
+        for path in api_paths:
+            data.extend(api_get(path=path)['data'])
 
     return _filter_sequences(data, seq_type, read)
 

--- a/austrakka/components/sequence/funcs.py
+++ b/austrakka/components/sequence/funcs.py
@@ -438,7 +438,7 @@ def _get_seq_api_sample_names(sample_ids: List[str]):
     return paths
 
 
-# pylint: disable=duplicate-code
+# pylint: disable=duplicate-code,no-else-return
 def _get_seq_data(
         seq_type: str,
         read: str,
@@ -458,7 +458,8 @@ def _get_seq_data(
         skipped_samples = [sample for sample in sample_ids if 
                            sample not in [item['sampleName'] for item in result]]
         if skipped_samples:
-            logger.warning(f'Skipped samples with no available sequences: {",".join(skipped_samples)}')
+            logger.warning('Skipped samples with no available sequences: '
+                           f'{",".join(skipped_samples)}')
         return result
 
 

--- a/austrakka/components/sequence/funcs.py
+++ b/austrakka/components/sequence/funcs.py
@@ -383,7 +383,8 @@ def _filter_sequences(data, seq_type, read) -> List[Dict]:
     data_filtered = list(filter(lambda x: x['isActive'] is True, data_filtered))
     if seq_type == FASTA_UPLOAD_TYPE:
         return data_filtered
-    data_filtered = list(filter(lambda x: read == READ_BOTH or x['read'] == int(read), data_filtered))
+    data_filtered = list(filter(lambda x: read == READ_BOTH or
+                                          x['read'] == int(read), data_filtered))
 
     # Find the 'sequenceID' values that are different among dictionaries in data_filtered
     different_sample_names = [item['sampleName'] for item in data
@@ -392,7 +393,8 @@ def _filter_sequences(data, seq_type, read) -> List[Dict]:
     if different_sample_names:
         for sample_name in different_sample_names:
             logger.warning(f"SampleName: {sample_name}, skipped...")
-        logger.warning("Items have been filtered out due to data being unavailable or in an incorrect format")
+        logger.warning("Items have been filtered out due to data"
+                       " being unavailable or in an incorrect format")
 
     return data_filtered
 

--- a/austrakka/components/sequence/funcs.py
+++ b/austrakka/components/sequence/funcs.py
@@ -27,6 +27,7 @@ from austrakka.utils.api import set_mode_header
 from austrakka.utils.enums.api import RESPONSE_TYPE_ERROR
 from austrakka.utils.paths import SEQUENCE_PATH
 from austrakka.utils.paths import SEQUENCE_BY_GROUP_PATH
+from austrakka.utils.paths import SEQUENCE_BY_SAMPLE_PATH
 from austrakka.utils.output import create_response_object
 from austrakka.utils.output import log_response
 from austrakka.utils.output import log_response_compact
@@ -55,7 +56,6 @@ FASTA_CSV_FILENAME = 'FileName'
 FASTA_CSV_FASTA_ID = 'FastaId'
 
 USE_IS_ACTIVE_FLAG = 'useIsActiveFlag'
-BY_SAMPLE = 'by-sample'
 
 
 @dataclass
@@ -380,6 +380,7 @@ def _download_sequences(
 
 def _filter_sequences(data, seq_type, read) -> List[Dict]:
     data = filter(lambda x: x['type'] == seq_type or seq_type is None, data)
+    data = filter(lambda x: x['isActive'] is True, data)
     if seq_type == FASTA_UPLOAD_TYPE:
         return list(data)
     data = filter(lambda x: read == READ_BOTH or x['read'] == int(read), data)
@@ -395,14 +396,34 @@ def _get_seq_api(group_name: str):
     return api_path
 
 
+def _get_seq_api_sample_names(sample_ids: List[str]):
+    api_path = SEQUENCE_PATH
+    paths = []
+    if sample_ids is not None:
+        for id in sample_ids:
+            api_path += f'/{SEQUENCE_BY_SAMPLE_PATH}/{id}'
+            paths.append(api_path)
+    else:
+        raise ValueError("A filter has not been passed")
+    return paths
+
+
 # pylint: disable=duplicate-code
 def _get_seq_data(
         seq_type: str,
         read: str,
         group_name: str,
+        sample_ids: List[str],
 ):
-    api_path = _get_seq_api(group_name)
-    data = api_get(path=api_path)['data']
+    data = []
+    if group_name == None:
+        api_path = _get_seq_api(group_name)
+        data = api_get(path=api_path)['data']
+    else:
+        api_paths = _get_seq_api_sample_names(sample_ids)
+        for p in api_paths:
+            data.extend(api_get(path=p)['data'])
+
     return _filter_sequences(data, seq_type, read)
 
 
@@ -411,7 +432,8 @@ def get_sequences(
         output_dir,
         seq_type: str,
         read: str,
-        group_name: str,
+        group_name: str = None,
+        sample_ids: List[str] = None,
 ):
     if not os.path.exists(output_dir):
         create_dir(output_dir)
@@ -420,6 +442,7 @@ def get_sequences(
         seq_type,
         read,
         group_name,
+        sample_ids,
     )
     _download_sequences(output_dir, data)
 
@@ -447,6 +470,6 @@ def purge_sequence(sample_id: str, skip: bool, force: bool):
     custom_headers = {}
     set_mode_header(custom_headers, force, skip)
     api_delete(
-        path="/".join([SEQUENCE_PATH, BY_SAMPLE, sample_id]),
+        path="/".join([SEQUENCE_PATH, SEQUENCE_BY_SAMPLE_PATH, sample_id]),
         custom_headers=custom_headers
     )

--- a/austrakka/components/sequence/sync/__init__.py
+++ b/austrakka/components/sequence/sync/__init__.py
@@ -1,8 +1,7 @@
 import click
 from click import option
 
-from austrakka.utils.options import opt_output_dir
-from austrakka.utils.options import opt_group
+from austrakka.utils.options import opt_output_dir, opt_group_name
 from austrakka.utils.options import opt_recalc_hash
 from austrakka.utils.options import opt_seq_type
 from austrakka.utils.options import opt_batch_size
@@ -18,7 +17,7 @@ def sync(ctx):
 
 @sync.command('get')
 @opt_output_dir()
-@opt_group(default=None, multiple=False, required=True)
+@opt_group_name(default=None, multiple=False, required=True)
 @opt_recalc_hash()
 @opt_seq_type(required=True)
 @opt_batch_size(help='Specifies the number of sequence downloads to perform '

--- a/austrakka/utils/options.py
+++ b/austrakka/utils/options.py
@@ -42,20 +42,20 @@ class RequiredMutuallyExclusiveOption(Option):
         if self.mutually_exclusive:
             ex_str = ', '.join(self.mutually_exclusive)
             kwargs['help'] = help_text + (
-                    'Mutually exclusive with [' + ex_str + ']'
-                    'At least one of these options are required'
+                    ' Mutually exclusive with [' + ex_str + ']'
+                    ' At least one of these options are required'
             )
         super().__init__(*args, **kwargs)
 
     def handle_parse_result(self, ctx, opts, args):
         if self.mutually_exclusive.intersection(opts) and self.name in opts:
             raise UsageError(
-                f"`{self.name}` is mutually exclusive "
+                f" `{self.name}` is mutually exclusive "
                 f"with `{', '.join(self.mutually_exclusive)}`."
             )
         if not self.mutually_exclusive.intersection(opts) and self.name not in opts:
             raise UsageError(
-                f"You must provide at least one of these arguments: "
+                f" You must provide at least one of these arguments: "
                 f"`{', '.join([self.name] + list(self.mutually_exclusive))}`."
             )
 

--- a/austrakka/utils/options.py
+++ b/austrakka/utils/options.py
@@ -42,7 +42,7 @@ class RequiredMutuallyExclusiveOption(Option):
         if self.mutually_exclusive:
             ex_str = ', '.join(self.mutually_exclusive)
             kwargs['help'] = help_text + (
-                    ' Mutually exclusive with [' + ex_str + ']'
+                    ' Mutually exclusive with [' + ex_str + '].'
                     ' At least one of these options are required'
             )
         super().__init__(*args, **kwargs)
@@ -121,7 +121,7 @@ def opt_group_name(var_name='group_name', **attrs: t.Any):
 
 def opt_sample_id(**attrs: t.Any):
     defaults = {
-        'required': False,
+        'required': True,
         'help': 'name',
         'multiple': True,
     }
@@ -233,7 +233,7 @@ def opt_organisation(**attrs: t.Any):
 
 def opt_group(**attrs: t.Any):
     defaults = {
-        'required': False,
+        'required': True,
         'multiple': True,
         'help': 'Name of group.'
     }

--- a/austrakka/utils/options.py
+++ b/austrakka/utils/options.py
@@ -53,7 +53,7 @@ class RequiredMutuallyExclusiveOption(Option):
                 f"`{self.name}` is mutually exclusive "
                 f"with `{', '.join(self.mutually_exclusive)}`."
             )
-        if not self.mutually_exclusive.intersection(opts) and not self.name in opts:
+        if not self.mutually_exclusive.intersection(opts) and self.name not in opts:
             raise UsageError(
                 f"You must provide at least one of these arguments: "
                 f"`{', '.join([self.name] + list(self.mutually_exclusive))}`."
@@ -121,7 +121,7 @@ def opt_group_name(var_name='group_name', **attrs: t.Any):
 
 def opt_sample_id(**attrs: t.Any):
     defaults = {
-        'required': True,
+        'required': False,
         'help': 'name',
         'multiple': True,
     }
@@ -233,7 +233,7 @@ def opt_organisation(**attrs: t.Any):
 
 def opt_group(**attrs: t.Any):
     defaults = {
-        'required': True,
+        'required': False,
         'multiple': True,
         'help': 'Name of group.'
     }

--- a/austrakka/utils/options.py
+++ b/austrakka/utils/options.py
@@ -231,30 +231,6 @@ def opt_organisation(**attrs: t.Any):
     )
 
 
-def opt_group(**attrs: t.Any):
-    defaults = {
-        'required': True,
-        'multiple': True,
-        'help': 'Name of group.'
-    }
-    return _create_option(
-        '-g',
-        '--group-name',
-        type=click.STRING,
-        **{**defaults, **attrs}
-    )
-
-
-def opt_groups(**attrs: t.Any):
-    return _create_option(
-        '-g',
-        '--group-names',
-        multiple=True,
-        type=click.STRING,
-        **attrs
-    )
-
-
 def opt_proforma(**attrs: t.Any):
     defaults = {
         'required': True,

--- a/austrakka/utils/paths.py
+++ b/austrakka/utils/paths.py
@@ -13,6 +13,7 @@ METADATACOLUMN_PATH = 'MetaDataColumns'
 METADATACOLUMNTYPE_PATH = 'MetaDataColumnType'
 METADATA_SEARCH_PATH = 'MetadataSearch'
 SEQUENCE_BY_GROUP_PATH = 'by-group'
+SEQUENCE_BY_SAMPLE_PATH = 'by-sample'
 SAMPLE_PATH = 'Sample'
 GROUP_PATH = 'Group'
 PLOT_PATH = "Plots"


### PR DESCRIPTION
Download fastq or fasta through listing samplesIds

Usages:
![image](https://github.com/AusTrakka/austrakka2-cli/assets/139199465/d47daa0f-0d2c-4c17-8f75-0ce02f9feb01)


![image](https://github.com/AusTrakka/austrakka2-cli/assets/139199465/7a86c7be-5f25-4ee6-8aac-2efd25ffd227)

![image](https://github.com/AusTrakka/austrakka2-cli/assets/139199465/b741865d-fbfa-4e08-8460-305be1b9d4ef)
skips incorrect items

Added extended permissions so that a seqViewer can also fetch sequences 
![image](https://github.com/AusTrakka/austrakka2-cli/assets/139199465/2f0dc5c0-68d1-4d16-a000-292660205ef6)
However only for the ones it has access to.