### PR TITLE
Rename field viz option

### DIFF
--- a/austrakka/components/field/__init__.py
+++ b/austrakka/components/field/__init__.py
@@ -29,10 +29,8 @@ def field_list(out_format: str):
 @click.option('--nndss', 'nndss',
               help="The corresponding National Notifiable Diseases Surveillance System label, "
                    "where it exists.")
-@click.option('--colour-nodes', 'colour_nodes', flag_value='viz',
-              help="This field may be used to colour nodes on the tree")
-@click.option('--no-colour-nodes', 'colour_nodes', flag_value='no_viz',
-              help="This field may not be used to colour nodes on the tree")
+@click.option('--viz/--no-viz', default=False,
+              help="This field may be used for colour visualisation in trees or plots")
 @click.option('-O', '--column-order', type=int, default=9000,
               help="Default order in which this column will be sorted in tables relative to other '"
                    "fields. If no value is specifed, the column will be placed after ordered "
@@ -42,11 +40,11 @@ def field_add(
         description: str,
         nndss: str,
         field_type: str,
-        colour_nodes: str,
+        viz: bool,
         column_order: int,
 ):
     """Add a metadata field to AusTrakka"""
-    add_field(name, description, nndss, field_type, colour_nodes, column_order)
+    add_field(name, description, nndss, field_type, viz, column_order)
 
 
 @field.command('update', hidden=hide_admin_cmds())
@@ -60,10 +58,8 @@ def field_add(
 @click.option('--nndss', 'nndss',
               help="The corresponding National Notifiable Diseases Surveillance System label, " 
                    "where it exists.")
-@click.option('--colour-nodes', 'colour_nodes', flag_value='viz',
-              help="This field may be used to colour nodes on the tree")
-@click.option('--no-colour-nodes', 'colour_nodes', flag_value='no_viz',
-              help="This field may not be used to colour nodes on the tree")
+@click.option('--viz/--no-viz', default=None,
+                help="This field may be used for colour visualisation in trees or plots")
 @click.option('-O', '--column-order', type=int, default=None,
               help="Default order in which this column will be sorted in tables relative to other "
                    "fields. If no value is specifed, the column will be placed after ordered "
@@ -74,7 +70,7 @@ def field_update(
         description: str,
         nndss: str,
         field_type: str,
-        colour_nodes: str,
+        viz: bool,
         column_order: int,
 ):
     """Update a metadata field within AusTrakka"""
@@ -84,6 +80,6 @@ def field_update(
         description,
         nndss,
         field_type,
-        colour_nodes,
+        viz,
         column_order,
     )

--- a/austrakka/components/field/funcs.py
+++ b/austrakka/components/field/funcs.py
@@ -52,10 +52,10 @@ def add_field(
     fieldtype = get_fieldtype_by_name(typename)
 
     if can_visualise and typename in ["date", "number", "string"]:
-            logger.warning(
-                f"Setting colour-nodes flag on field {name} of type {typename}. "
-                f"This may work poorly as colour visualisations are configured for a small "
-                f"discrete set of values.")
+        logger.warning(
+            f"Setting colour-nodes flag on field {name} of type {typename}. "
+            f"This may work poorly as colour visualisations are configured for a small "
+            f"discrete set of values.")
     else:
         # Set visualisation behaviour based on field type
         # Here booleans and categoricals give True

--- a/austrakka/components/field/funcs.py
+++ b/austrakka/components/field/funcs.py
@@ -109,6 +109,8 @@ def update_field(
         "columnOrder",
         "isActive",
         "metaDataColumnTypeId",
+        "description",
+        "nndssFieldLabel"
     ]}
 
     if new_name is not None:

--- a/austrakka/components/field/funcs.py
+++ b/austrakka/components/field/funcs.py
@@ -53,7 +53,7 @@ def add_field(
 
     if can_visualise and typename in ["date", "number", "string"]:
         logger.warning(
-            f"Setting colour-nodes flag on field {name} of type {typename}. "
+            f"Setting viz flag on field {name} of type {typename}. "
             f"This may work poorly as colour visualisations are configured for a small "
             f"discrete set of values.")
     else:
@@ -61,9 +61,9 @@ def add_field(
         # Here booleans and categoricals give True
         if typename == "string":
             logger.warning(
-                f"Setting default of --no-colour-nodes on field {name} due to type {typename}. "
+                f"Setting default of --no-viz on field {name} due to type {typename}. "
                 f"If this string field should be allowed to be used for colour visualisations, "
-                f"set --colour-nodes.")
+                f"set --viz.")
         can_visualise = (typename not in ["date", "number", "string"])
 
     api_post(

--- a/austrakka/components/field/funcs.py
+++ b/austrakka/components/field/funcs.py
@@ -43,7 +43,7 @@ def add_field(
         description: str,
         nndss_label: str,
         typename: str,
-        can_visualise: str,
+        can_visualise: bool,
         column_order: int,
 ):
     """
@@ -51,17 +51,12 @@ def add_field(
     """
     fieldtype = get_fieldtype_by_name(typename)
 
-    if can_visualise == 'viz':
-        if typename in ["date", "number", "string"]:
+    if can_visualise and typename in ["date", "number", "string"]:
             logger.warning(
                 f"Setting colour-nodes flag on field {name} of type {typename}. "
                 f"This may work poorly as colour visualisations are configured for a small "
                 f"discrete set of values.")
-        can_visualise = True
-    elif can_visualise == 'no_viz':
-        can_visualise = False
     else:
-        assert can_visualise is None
         # Set visualisation behaviour based on field type
         # Here booleans and categoricals give True
         if typename == "string":
@@ -92,7 +87,7 @@ def update_field(
         description: str,
         nndss_label: str,
         typename: str,
-        can_visualise: str,
+        can_visualise: bool,
         column_order: int,
 ):
     """
@@ -122,13 +117,13 @@ def update_field(
         put_field["metaDataColumnTypeId"] = fieldtype["metaDataColumnTypeId"]
 
     if can_visualise is not None:
-        if can_visualise == 'viz':
+        if can_visualise:
             if typename in ["date", "number", "string"]:
                 logger.warning(
                     f"Setting colour-nodes flag on field {name} of type {typename}. "
                     f"This may work poorly as colour visualisations are configured for a "
                     f"small discrete set of values.")
-        put_field["canVisualise"] = can_visualise == 'viz'
+        put_field["canVisualise"] = can_visualise
 
     if column_order is not None:
         put_field["columnOrder"] = column_order


### PR DESCRIPTION
Rename the --colour-nodes parameter in the CLI field commands. This controls the canVisualise property in the database, which by this stage affects more than just node colouring.