### PR TITLE
Prevent integers from being converted to floating-point format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,7 @@ and this project adheres to [Semantic Versioning].
 - Initialising of `seq sync get` manifest file for empty list of sequences
 
 ### Changed
-- Allow data dictionary to distinguish minimum metadata from other classes; colour fields by class
-- Sort metadata fields by metadata class
-- Write project group name, not project name
+- Improvements to auto-generation of proforma template
 - Allow CLI version check to be skipped
 
 ### Added

--- a/austrakka/utils/output.py
+++ b/austrakka/utils/output.py
@@ -132,7 +132,7 @@ def _get_output_extension(output_format: str):
 def _create_dataframe(
         data: dict
 ) -> pd.DataFrame:
-    return pd.DataFrame.from_dict(data)
+    return pd.DataFrame.from_dict(data, dtype=object)
 
 
 def write_dataframe(


### PR DESCRIPTION
Prevent integers from being converted to floating-point format in metadata get commands; replace some ambiguous changelog messages