### PR TITLE
AB#5970 Always convert sample names to string when reading from a dataframe.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+# [0.58.3] - 2024-08-09
+### Fixed
+- Fixed `sync get` command to correctly handle numeric sequence IDs.
+
 # [0.58.2] - 2024-08-07
 ### Added
 - Can now set analysis server username in `user` commands.

--- a/austrakka/__init__.py
+++ b/austrakka/__init__.py
@@ -1,3 +1,3 @@
 # NOTE: do not change the name of this variable or the quote type,
 # doing so will break github actions.
-__version__ = "0.58.2"
+__version__ = "0.58.3"

--- a/austrakka/components/sequence/sync/sync_workflow.py
+++ b/austrakka/components/sequence/sync/sync_workflow.py
@@ -370,16 +370,18 @@ def finalise_each_file(int_med, sync_state):
     output_dir = get_output_dir(sync_state)
     for index, row in int_med.iterrows():
 
+        sample_name = str(row[SAMPLE_NAME_KEY])
+
         dest = os.path.join(
             output_dir,
-            row[SAMPLE_NAME_KEY],
+            sample_name,
             row[TYPE_KEY],
             row[FILE_NAME_ON_DISK_KEY])
 
         if row[STATUS_KEY] == DRIFTED:
             src = os.path.join(
                 output_dir,
-                row[SAMPLE_NAME_KEY],
+                sample_name,
                 row[TYPE_KEY],
                 row[HOT_SWAP_NAME_KEY])
 
@@ -540,7 +542,7 @@ def get_file_from_server(data_frame, index, row, sync_state):
     file_path = ""
     try:
         filename = row[FILE_NAME_ON_DISK_KEY]
-        sample_name = row[SAMPLE_NAME_KEY]
+        sample_name = str(row[SAMPLE_NAME_KEY])
         read = str(row[READ_KEY])
         seq_type = row[TYPE_KEY]
         dest_dir = os.path.join(get_output_dir(sync_state), sample_name, seq_type)
@@ -566,7 +568,7 @@ def get_file_from_server(data_frame, index, row, sync_state):
         check_download_hash(data_frame, file_path, index, row)
 
         # Drifted entries are left for finalisation to hot swap.
-        # Otherwise mark the entry as successfully downloaded.
+        # Otherwise, mark the entry as successfully downloaded.
         if data_frame.at[index, STATUS_KEY] != DRIFTED and \
                 data_frame.at[index, STATUS_KEY] != FAILED:
 


### PR DESCRIPTION
[AB#5970](https://dev.azure.com/mduphl/66de697f-df03-4f5d-b5b4-0df4487db257/_workitems/edit/5970) Hot fix for APG sync process.