### PR TITLE
6488 replace sample id with seq

### DIFF
--- a/austrakka/components/analysis/definition/__init__.py
+++ b/austrakka/components/analysis/definition/__init__.py
@@ -13,7 +13,7 @@ from austrakka.utils.options import opt_is_active
 @click.group()
 @click.pass_context
 def definition(ctx):
-    """Commands related to analyses"""
+    """Commands related to analysis definitions"""
     ctx.context = ctx.parent.context
 
 

--- a/austrakka/components/dashboard/project/__init__.py
+++ b/austrakka/components/dashboard/project/__init__.py
@@ -13,15 +13,14 @@ from ....utils.options import *
 @click.group()
 @click.pass_context
 def project(ctx):
-    """Commands related to defining a project dashboard, which is a type of dashboard
-    for showing in a project UI."""
+    """Commands related to defining a project dashboard"""
     ctx.context = ctx.parent.context
 
 
 @project.command('add', hidden=hide_admin_cmds())
 @opt_name(help="Dashboard name. Must be unique.")
 def dashboard_add(name: str):
-    """Define a dashboard"""
+    """Define a project dashboard"""
     add_dashboard(name)
 
 
@@ -29,14 +28,14 @@ def dashboard_add(name: str):
 @opt_name(help="Dashboard name. Must be unique.")
 @click.argument('dashboard-id', type=int)
 def dashboard_update(dashboard_id: int, name: str):
-    """Update a dashboard definition"""
+    """Update a project dashboard definition"""
     update_dashboard(dashboard_id, name)
 
 
 @project.command('list', hidden=hide_admin_cmds())
 @table_format_option()
 def dashboards_list(out_format: str):
-    """List dashboards available for use in a given project."""
+    """List project dashboards available for use in a given project"""
     list_dashboards(out_format)
 
 
@@ -44,5 +43,5 @@ def dashboards_list(out_format: str):
 @click.argument('dashboard-id', type=int)
 @opt_new_name(help="New name of dashoard.", )
 def dashboard_rename(dashboard_id: int, new_name: str):
-    """Define a dashboard, including what widgets to show."""
+    """Rename a project dashboard"""
     rename_dashboard(dashboard_id, new_name)

--- a/austrakka/components/dashboard/project/funcs.py
+++ b/austrakka/components/dashboard/project/funcs.py
@@ -49,7 +49,7 @@ def list_dashboards(out_format: str):
 @logger_wraps()
 def rename_dashboard(dashboard_id: int, new_name: str):
     """
-    List dashboards available for use in a project.
+    Rename a dashboard.
     """
     api_patch(
         path=f'{PROJECT_DASHBOARD_PATH}/{RENAME}/{dashboard_id}',

--- a/austrakka/components/proforma/__init__.py
+++ b/austrakka/components/proforma/__init__.py
@@ -60,7 +60,8 @@ def proforma_add(
     Add a new proforma to AusTrakka.
     This adds a validation spec which may be selected to upload data. 
     This will add a new proforma with a new abbreviation, not a new version of an existing proforma.
-    This command does not add the Excel proforma template document; that should be added wih the 'attach' command.
+    This command does not add the Excel proforma template document; 
+    that should be added wih the 'attach' command.
     """
     add_proforma(
         abbrev,
@@ -111,7 +112,7 @@ def proforma_attach(proforma_abbrev: str,
                     file_path: str = None,
                     n_previous: int = None):
     """
-    This command will attach a new or existing file to the latest version of the specified proforma.
+    Attach a new or existing file to the latest version of the specified proforma.
 
     Usage:
 

--- a/austrakka/components/proforma/__init__.py
+++ b/austrakka/components/proforma/__init__.py
@@ -24,7 +24,7 @@ from ...utils.options import *
 @click.group()
 @click.pass_context
 def proforma(ctx):
-    """Commands related to metadata pro formas"""
+    """Commands related to metadata proformas"""
     ctx.context = ctx.parent.context
 
 # proforma-specific options used in multiple commands
@@ -57,8 +57,10 @@ def proforma_add(
         required_field: List[str],
         optional_field: List[str]):
     """
-    Add a new pro forma to AusTrakka.
-    This will add a new pro forma with a new abbreviation, not a new version.
+    Add a new proforma to AusTrakka.
+    This adds a validation spec which may be selected to upload data. 
+    This will add a new proforma with a new abbreviation, not a new version of an existing proforma.
+    This command does not add the Excel proforma template document; that should be added wih the 'attach' command.
     """
     add_proforma(
         abbrev,
@@ -76,7 +78,7 @@ def proforma_update(
         required_field: List[str],
         optional_field: List[str]):
     """
-    Update a pro forma with a new set of fields.
+    Update a proforma with a new set of fields.
     The fields specified by -req and -opt will fully replace the fields in the current version.
     Any fields in the current version but not listed in the update will be removed.
     """
@@ -109,17 +111,17 @@ def proforma_attach(proforma_abbrev: str,
                     file_path: str = None,
                     n_previous: int = None):
     """
-    This command will attach a file or pull a existing file to latest ProForma Version
+    This command will attach a new or existing file to the latest version of the specified proforma.
 
     Usage:
 
     austrakka proforma attach [PROFORMA_ABBREV] 
-    ~~This will pull the file from the last proforma version
+    ~~This will pull the most recent existing file from a previous proforma version
 
-    austrakka proforma attach [PROFORMA_ABBREV] -f [FILEPATH] ~~attaches given file
+    austrakka proforma attach [PROFORMA_ABBREV] -f [FILEPATH] ~~uploads and attaches a new file
 
     austrakka proforma attach [PROFORMA_ABBREV] -id [PROFORMA-VERSION-ID]
-    ~~this pulls a file from specified id
+    ~~This will pull an existing file from a previous proforma version
     """
     if file_path is None:
         pull_proforma(proforma_abbrev, n_previous)
@@ -170,7 +172,7 @@ def proforma_generate(proforma_abbrev: str, restrict, nndss, project, metadata_c
 @proforma.command('list')
 @table_format_option()
 def proforma_list(out_format: str):
-    """List metadata pro formas in AusTrakka"""
+    """List metadata proformas in AusTrakka"""
     list_proformas(out_format)
 
 
@@ -191,7 +193,7 @@ def proforma_show(proforma_abbrev: str, out_format: str):
 # Consider option instead: @opt_abbrev("Abbreviated name of the pro forma")
 def proforma_disable(proforma_abbrev: str):
     """
-    Disable a pro forma.
+    Disable a proforma.
     """
     disable_proforma(proforma_abbrev)
 
@@ -201,7 +203,7 @@ def proforma_disable(proforma_abbrev: str):
 # Consider option instead: @opt_abbrev("Abbreviated name of the pro forma")
 def proforma_enable(proforma_abbrev: str):
     """
-    Enable a pro forma.
+    Re-enable a proforma.
     """
     enable_proforma(proforma_abbrev)
 
@@ -211,8 +213,8 @@ def proforma_enable(proforma_abbrev: str):
 @opt_group_name(var_name='group_names', multiple=True)
 def proforma_share(proforma_abbrev: str, group_names: List[str]):
     """
-    Share a pro forma with one or more groups, which may be project groups. 
-    The pro forma will be visible and useable by Uploaders in these groups.
+    Share a proforma with one or more groups, which may be project groups. 
+    The proforma will be visible and useable by Uploaders in these groups.
     """
     share_proforma(proforma_abbrev, group_names)
 
@@ -222,7 +224,7 @@ def proforma_share(proforma_abbrev: str, group_names: List[str]):
 @opt_group_name(var_name='group_names', multiple=True)
 def proforma_unshare(proforma_abbrev: str, group_names: List[str]):
     """
-    UnShare a pro forma with one or more groups.
+    Unshare a proforma with one or more groups.
     """
     unshare_proforma(proforma_abbrev, group_names)
 
@@ -232,6 +234,6 @@ def proforma_unshare(proforma_abbrev: str, group_names: List[str]):
 @table_format_option()
 def proforma_list_groups(proforma_abbrev: str, out_format: str):
     """
-    List groups who have access to the given pro forma.
+    List groups which have access to the given proforma.
     """
     list_groups_proforma(proforma_abbrev, out_format)

--- a/austrakka/components/project/dataset/__init__.py
+++ b/austrakka/components/project/dataset/__init__.py
@@ -12,7 +12,7 @@ from austrakka.utils.output import table_format_option
 @click.group()
 @click.pass_context
 def dataset(ctx):
-    """Commands to manage project datasets for analysis metadata"""
+    """Commands to manage project datasets"""
     ctx.context = ctx.parent.context
 
 

--- a/austrakka/components/project/metadata/__init__.py
+++ b/austrakka/components/project/metadata/__init__.py
@@ -44,7 +44,7 @@ def get_dataset_view(
         view_id: Optional[str],
         out_format: str,
 ):
-    """Get a specific metadata view."""
+    """Get a specific metadata view. By default, the full metadata view is returned."""
     download_dataset_view(view_id, project_abbrev, out_format)
 
 

--- a/austrakka/components/project/provision/__init__.py
+++ b/austrakka/components/project/provision/__init__.py
@@ -28,7 +28,7 @@ def provision(ctx):
 @click.argument('project-abbrev', type=str)
 @opt_field_name()
 def project_add_provision(project_abbrev: str, field_names: List[str]):
-    """This will add a project provision"""
+    """Add a project provision"""
     add_provision_project(project_abbrev, field_names)
 
 
@@ -36,7 +36,7 @@ def project_add_provision(project_abbrev: str, field_names: List[str]):
 @click.argument('project-abbrev', type=str)
 @opt_prov_id()
 def project_remove_provision(project_abbrev: str, prov_id: str):
-    """This will remove a project provision"""
+    """Remove a project provision"""
     remove_project_provision(project_abbrev, prov_id)
 
 
@@ -45,7 +45,7 @@ def project_remove_provision(project_abbrev: str, prov_id: str):
 @opt_field_name()
 @opt_prov_id()
 def project_update_provision(project_abbrev: str, field_names: List[str], prov_id: str):
-    """This will update a project provision by replacing the current list of fields
+    """Update a project provision by replacing the current list of fields
     with the new list of fields."""
     update_project_provision(project_abbrev, prov_id, field_names)
 
@@ -54,5 +54,5 @@ def project_update_provision(project_abbrev: str, field_names: List[str], prov_i
 @table_format_option()
 @click.argument('project-abbrev', type=str)
 def project_list_provisions(project_abbrev: str, out_format: str):
-    """This will list project provisions"""
+    """List project provisions for a given project"""
     get_dataset_provision_list(project_abbrev, out_format)

--- a/austrakka/components/sample/__init__.py
+++ b/austrakka/components/sample/__init__.py
@@ -2,7 +2,7 @@
 from io import BufferedReader
 import click
 
-from austrakka.utils.options import opt_sample_id, opt_group_name
+from austrakka.utils.options import opt_seq_id, opt_group_name
 from austrakka.utils.cmd_filter import hide_admin_cmds
 from ...utils.output import table_format_option
 from ...utils.output import object_format_option
@@ -23,75 +23,76 @@ def sample(ctx):
     ctx.context = ctx.parent.context
 
 @sample.command('show', hidden=hide_admin_cmds())
-@opt_sample_id(multiple=False)
+@opt_seq_id(multiple=False)
 @object_format_option()
-def sample_show(sample_id: str, out_format: str):
-    show_sample(sample_id, out_format)
+def sample_show(seq_id: str, out_format: str):
+    show_sample(seq_id, out_format)
 
 
 @sample.command('unshare')
 @opt_group_name()
-@opt_sample_id(
-    help='The id of the sample to be unshared. Multiple ids can be specified.'
+@opt_seq_id(
+    help='The Seq_ID of the sample record(s) to be unshared. Multiple Seq_IDs can be specified.'
          'Eg. -s sample1 -s sample2')
-def sample_unshare(sample_id: [str], group_name: str):
+def sample_unshare(seq_id: [str], group_name: str):
     """Unshare a list of samples with a group."""
-    unshare_sample(sample_id, group_name)
+    unshare_sample(seq_id, group_name)
 
 
 @sample.command('share')
 @opt_group_name()
-@opt_sample_id(
-    help='The id of the sample to be shared. Multiple ids can be specified.'
+@opt_seq_id(
+    help='The Seq_ID of the sample record(s) to be shared. Multiple Seq_IDs can be specified.'
          'Eg. -s sample1 -s sample2')
-def sample_share(sample_id: [str], group_name: str):
-    """Share a list of samples with a group."""
-    share_sample(sample_id, group_name)
+def sample_share(seq_id: [str], group_name: str):
+    """Share a list of sample records with a group."""
+    share_sample(seq_id, group_name)
 
 
 @sample.command('disable')
-@opt_sample_id(
-    help='The id of the sample to be removed. Multiple ids can be specified.'
+@opt_seq_id(
+    help='The Seq_ID of the sample record(s) to be removed. Multiple Seq_IDs can be specified.'
     'Eg. -s sample1 -s sample2')
-def sample_disable(sample_id: [str]):
-    """Disable a sample. This is like a soft delete. It may be purged
-    after 30 days. Once disabled, it will not be possible to upload metadata or sequences
+def sample_disable(seq_id: [str]):
+    """Disable a sample record. This is like a soft delete. 
+    The sample record's metadata and sequences will not appear in any projects. 
+    Once disabled, it will not be possible to upload metadata or sequences
     to the sample until it is enabled again, or until it has been purged
     from the system."""
-    disable_sample(sample_id)
+    disable_sample(seq_id)
 
 
 @sample.command('groups')
 @table_format_option()
-@opt_sample_id(multiple=False)
+@opt_seq_id(multiple=False)
 def seq_groups(
-        sample_id: str,
+        seq_id: str,
         out_format: str
 ):
-    """List the groups that the sample is in (shared with, or owned by)."""
+    """List the groups that the sample record is in (shared with, or owned by)."""
     get_groups(
-        sample_id,
+        seq_id,
         out_format,
     )
 
 
 @sample.command('enable')
-@opt_sample_id(
-    help='The id of the sample to be re-enable. Multiple ids can be specified.'
+@opt_seq_id(
+    help='The Seq_ID of the sample record(s) to be re-enabled. Multiple Seq_IDs can be specified.'
     'Eg. -s sample1 -s sample2')
-def sample_enable(sample_id: [str]):
+def sample_enable(seq_id: [str]):
     """Enable a sample. This re-enables a previously disabled sample."""
-    enable_sample(sample_id)
+    enable_sample(seq_id)
 
 
 @sample.command('purge', hidden=hide_admin_cmds())
-@opt_sample_id(
-    help='The id of the sample to be purged.',
+@opt_seq_id(
+    help='The Seq_ID of the sample record to be purged.',
     multiple=False)
-def sample_purge(sample_id: str):
-    """Purge a sample. This will purge all metadata including the original CSV 
+def sample_purge(seq_id: str):
+    """Purge a sample record. This will purge all metadata including the original CSV 
     file which it was uploaded from. If more than one sample was uploaded from 
     the same CSV file, the other samples will not be purged, but will lose the 
     link to the original CSV file. This action is irreversible. Any sequences 
     must be purged prior to purging the sample."""
-    purge_sample(sample_id)
+    purge_sample(seq_id)

--- a/austrakka/components/sample/__init__.py
+++ b/austrakka/components/sample/__init__.py
@@ -26,6 +26,7 @@ def sample(ctx):
 @opt_seq_id(multiple=False)
 @object_format_option()
 def sample_show(seq_id: str, out_format: str):
+    """Show all available information about a sample record."""
     show_sample(seq_id, out_format)
 
 
@@ -35,7 +36,7 @@ def sample_show(seq_id: str, out_format: str):
     help='The Seq_ID of the sample record(s) to be unshared. Multiple Seq_IDs can be specified.'
          'Eg. -s sample1 -s sample2')
 def sample_unshare(seq_id: [str], group_name: str):
-    """Unshare a list of samples with a group."""
+    """Unshare a list of sample records with a group."""
     unshare_sample(seq_id, group_name)
 
 
@@ -54,7 +55,7 @@ def sample_share(seq_id: [str], group_name: str):
     help='The Seq_ID of the sample record(s) to be removed. Multiple Seq_IDs can be specified.'
     'Eg. -s sample1 -s sample2')
 def sample_disable(seq_id: [str]):
-    """Disable a sample record. This is like a soft delete. 
+    """Disable a sample record. This is a soft delete. 
     The sample record's metadata and sequences will not appear in any projects. 
     Once disabled, it will not be possible to upload metadata or sequences
     to the sample until it is enabled again, or until it has been purged
@@ -81,7 +82,7 @@ def seq_groups(
     help='The Seq_ID of the sample record(s) to be re-enabled. Multiple Seq_IDs can be specified.'
     'Eg. -s sample1 -s sample2')
 def sample_enable(seq_id: [str]):
-    """Enable a sample. This re-enables a previously disabled sample."""
+    """Enable a sample record. This re-enables a previously disabled sample."""
     enable_sample(seq_id)
 
 
@@ -90,9 +91,9 @@ def sample_enable(seq_id: [str]):
     help='The Seq_ID of the sample record to be purged.',
     multiple=False)
 def sample_purge(seq_id: str):
-    """Purge a sample record. This will purge all metadata including the original CSV 
-    file which it was uploaded from. If more than one sample was uploaded from 
-    the same CSV file, the other samples will not be purged, but will lose the 
-    link to the original CSV file. This action is irreversible. Any sequences 
+    """Purge a sample record. This will purge all metadata including any CSV or Excel
+    files used to upload metadata, and including the original upload. If other Seq_IDs were  
+    uploaded in the same CSV/Excel files, the other samples will not be purged, but will lose the 
+    link to the original CSV/Excel file. This action is irreversible. Any sequences 
     must be purged prior to purging the sample."""
     purge_sample(seq_id)

--- a/austrakka/components/sample/funcs.py
+++ b/austrakka/components/sample/funcs.py
@@ -14,24 +14,24 @@ PURGE = 'Purge'
 
 @logger_wraps()
 def show_sample(
-        sample_id: str,
+        seq_id: str,
         out_format: str,
 ):
     call_get_and_print(
-        path="/".join([SAMPLE_PATH, sample_id]),
+        path="/".join([SAMPLE_PATH, seq_id]),
         out_format=out_format
     )
 
 
 @logger_wraps()
 def share_sample(
-        sample_ids: [str],
+        seq_ids: [str],
         group_name: str
 ):
     api_patch(
         path="/".join([SAMPLE_PATH, SHARE]),
         data={
-            "seqIds": sample_ids,
+            "seqIds": seq_ids,
             "groupName": group_name
         },
     )
@@ -39,13 +39,13 @@ def share_sample(
 
 @logger_wraps()
 def unshare_sample(
-        sample_ids: [str],
+        seq_ids: [str],
         group_name: str
 ):
     api_patch(
         path="/".join([SAMPLE_PATH, UNSHARE]),
         data={
-            "seqIds": sample_ids,
+            "seqIds": seq_ids,
             "groupName": group_name
         },
     )
@@ -53,40 +53,40 @@ def unshare_sample(
 
 @logger_wraps()
 def get_groups(
-        sample_id: str,
+        seq_id: str,
         out_format
 ):
-    data = api_get(path=f"{SAMPLE_PATH}/{sample_id}/{GROUPS}")['data']
+    data = api_get(path=f"{SAMPLE_PATH}/{seq_id}/{GROUPS}")['data']
     format_group_dto_for_output(data, out_format)
 
 @logger_wraps()
 def disable_sample(
-        sample_ids: [str]
+        seq_ids: [str]
 ):
     api_patch(
         path="/".join([SAMPLE_PATH, DISABLE]),
         data={
-            "seqIds": sample_ids
+            "seqIds": seq_ids
         },
     )
 
 
 @logger_wraps()
 def enable_sample(
-        sample_ids: [str]
+        seq_ids: [str]
 ):
     api_patch(
         path="/".join([SAMPLE_PATH, ENABLE]),
         data={
-            "seqIds": sample_ids
+            "seqIds": seq_ids
         },
     )
 
 
 @logger_wraps()
 def purge_sample(
-        sample_id: str
+        seq_id: str
 ):
     api_patch(
-        path="/".join([SAMPLE_PATH, sample_id, PURGE]),
+        path="/".join([SAMPLE_PATH, seq_id, PURGE]),
     )

--- a/austrakka/components/sequence/__init__.py
+++ b/austrakka/components/sequence/__init__.py
@@ -9,7 +9,7 @@ from austrakka.utils.option_utils import RequiredMutuallyExclusiveOption
 from austrakka.utils.options import opt_seq_type
 from austrakka.utils.options import opt_group_name
 from austrakka.utils.options import opt_output_dir
-from austrakka.utils.options import opt_sample_id
+from austrakka.utils.options import opt_seq_id
 from austrakka.utils.options import opt_force_mutex_skip
 from austrakka.utils.options import opt_skip_mutex_force
 from austrakka.utils.options import opt_delete_all
@@ -42,8 +42,8 @@ seq.add_command(sync)
     default=None,
     multiple=False,
     cls=RequiredMutuallyExclusiveOption,
-    mutually_exclusive=['sample_id'])
-@opt_sample_id(
+    mutually_exclusive=['seq_id'])
+@opt_seq_id(
     required=False,
     default=None,
     help='The Seq_IDs of specific sequences to download',
@@ -53,7 +53,7 @@ def seq_get(
         output_dir,
         seq_type: str,
         group_name: str,
-        sample_id: List[str],
+        seq_id: List[str],
 ):
     """Download sequence files to the local drive
 
@@ -65,7 +65,7 @@ def seq_get(
         output_dir,
         seq_type,
         group_name,
-        sample_id,
+        seq_id,
     )
 
 
@@ -77,8 +77,8 @@ def seq_get(
     default=None,
     multiple=False,
     cls=RequiredMutuallyExclusiveOption,
-    mutually_exclusive=['sample_id'])
-@opt_sample_id(
+    mutually_exclusive=['seq_id'])
+@opt_seq_id(
     required=False,
     default=None,
     help='The Seq_IDs of specific sequences to download',
@@ -88,20 +88,20 @@ def seq_list(
         out_format: str,
         seq_type: str,
         group_name: str,
-        sample_id: List[str],
+        seq_id: List[str],
 ):
     """List sequences for a group or sample"""
     list_sequences(
         out_format,
         seq_type,
         group_name,
-        sample_id
+        seq_id
     )
 
 
 @seq.command('purge', hidden=hide_admin_cmds())
-@opt_sample_id(
-    help='The id of the sample which needs to have sequences purged.',
+@opt_seq_id(
+    help='The Seq_ID of the sample which needs to have sequences purged.',
     multiple=False
 )
 @opt_seq_type()
@@ -111,10 +111,10 @@ def seq_list(
 @opt_delete_all(help='Delete active and inactive sequences for the specified sample. '
                      'By default, only inactive sequences are deleted.')
 def sequence_purge(
-        sample_id: [str],
+        seq_id: [str],
         seq_type: str,
         skip: bool = False,
         force: bool = False,
         delete_all: bool = False):
     """Purge all sequences associated with the specified sample."""
-    purge_sequence(sample_id, seq_type, skip, force, delete_all)
+    purge_sequence(seq_id, seq_type, skip, force, delete_all)

--- a/austrakka/components/sequence/__init__.py
+++ b/austrakka/components/sequence/__init__.py
@@ -116,5 +116,5 @@ def sequence_purge(
         skip: bool = False,
         force: bool = False,
         delete_all: bool = False):
-    """Purge all sequences associated with the specified sample."""
+    """Purge all sequences associated with the specified Seq_ID."""
     purge_sequence(seq_id, seq_type, skip, force, delete_all)

--- a/austrakka/utils/options.py
+++ b/austrakka/utils/options.py
@@ -117,15 +117,15 @@ def opt_group_name(var_name='group_name', **attrs: t.Any):
     )
 
 
-def opt_sample_id(**attrs: t.Any):
+def opt_seq_id(**attrs: t.Any):
     defaults = {
         'required': True,
-        'help': 'name',
+        'help': 'Seq_ID of the record',
         'multiple': True,
     }
     return create_option(
         "-s",
-        "--sample-id",
+        "--seq-id",
         type=click.STRING,
         **{**defaults, **attrs}
     )


### PR DESCRIPTION
Replace the --sample-id option everywhere with --seq-id. Short form still -s.

Technically, this is a breaking change, and should be versioned as such.

Also minor updates to help text to make command descriptions more consistent. This is in a separate commit.