### PR TITLE
AB#4822 Removed the ability to update a projects abbreviations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+# [Unreleased]
+### Changed
+- Updated the 'project update' command so that a user cannot update the project abbreviation.
+
 # [0.68.1]
 ### Changed 
 - Field Source is now listed as a column in the `project field list` command.

--- a/austrakka/components/project/__init__.py
+++ b/austrakka/components/project/__init__.py
@@ -67,7 +67,6 @@ def project_add(
         help=f'Update an existing project in {PROG_NAME}.',
 )
 @click.argument('project-abbrev', type=str)
-@opt_abbrev(help="New project abbreviation", required=False)
 @opt_name(help="New project name", required=False)
 @opt_description(help="New project description", required=False)
 @opt_is_active(help="Set project active status", is_update=True, required=False)
@@ -76,7 +75,6 @@ def project_add(
 @opt_type(help="New project type", required=False)
 def project_update(
         project_abbrev: str,
-        abbrev: str,
         name: str,
         description: str,
         is_active: bool,
@@ -84,7 +82,6 @@ def project_update(
         dashboard_name: str,
         project_type: str):
     update_project(project_abbrev,
-                   abbrev,
                    name,
                    description,
                    is_active,

--- a/austrakka/components/project/funcs.py
+++ b/austrakka/components/project/funcs.py
@@ -67,7 +67,6 @@ def add_project(
 @logger_wraps()
 def update_project(
         project_abbreviation: str,
-        abbrev: str,
         name: str,
         description: str,
         is_active: bool,
@@ -78,7 +77,6 @@ def update_project(
 
     # ProjectDTO fields which should go in ProjectPutDTO
     put_project = {k: project[k] for k in [
-        'abbreviation',
         'name',
         'description',
         'isActive',
@@ -89,9 +87,6 @@ def update_project(
     if project['requestingOrg'] is None:
         put_project['requestingOrg'] = {'abbreviation': None}
 
-    if abbrev is not None:
-        logger.warning(f"Updating project abbreviation from {project['abbreviation']} to {abbrev}")
-        put_project['abbreviation'] = abbrev
     if name is not None:
         put_project['name'] = name
     if description is not None:

--- a/austrakka/components/project/funcs.py
+++ b/austrakka/components/project/funcs.py
@@ -1,6 +1,4 @@
 # pylint: disable=duplicate-code
-
-from loguru import logger
 import pandas as pd
 
 from austrakka.utils.api import api_post, \


### PR DESCRIPTION
This was done as the underlying group name does not change with it-as it is linked.

Since the link between group name and abbrev will be severed in the future. Removal seemed like the best course of action as it is a key system field that should not be changed.

Dependent Branch:

[Portal](https://github.com/AusTrakka/austrakka-portal/pull/1946)