### PR TITLE
AB#5872 added support for new property for field examples

### DIFF
--- a/austrakka/components/field/__init__.py
+++ b/austrakka/components/field/__init__.py
@@ -43,6 +43,7 @@ def field_list(view_type: str, out_format: str):
                     "columns.")
 @click.option('--viz/--no-viz', default=False,
               help="This field may be used for colour visualisation in trees or plots")
+@opt_examples()
 @opt_private()
 def field_add(
         name: str,
@@ -52,8 +53,9 @@ def field_add(
         viz: bool,
         column_order: int,
         is_private: bool,
+        examples: str,
 ):
-    add_field(name, description, nndss, field_type, viz, column_order, is_private)
+    add_field(name, description, nndss, field_type, viz, column_order, is_private, examples)
 
 
 @field.command(
@@ -67,6 +69,7 @@ def field_add(
 @opt_fieldtype(required=False)
 @opt_description(required=False, help="This field describes the purpose of the metadata field. "
                                       "Its value is also used for generating XLSX pro forma files.")
+@opt_examples()
 @create_option('--nndss', 'nndss',
                help="The corresponding National Notifiable Diseases Surveillance System label, "
                     "where it exists.")
@@ -81,6 +84,7 @@ def field_update(
         fieldname: str,
         name: str,
         description: str,
+        examples: str,
         nndss: str,
         field_type: str,
         viz: bool,
@@ -91,6 +95,7 @@ def field_update(
         fieldname,
         name,
         description,
+        examples,
         nndss,
         field_type,
         viz,

--- a/austrakka/components/field/funcs.py
+++ b/austrakka/components/field/funcs.py
@@ -60,6 +60,7 @@ def add_field(
         can_visualise: bool,
         column_order: int,
         private: bool,
+        examples: str,
 ):
     """
     Add a field (MetaDataColumn) to AusTrakka.
@@ -93,6 +94,7 @@ def add_field(
             "IsActive": True,
             "IsPrivate": private,
             "Description": description,
+            "Examples": examples,
             "NndssFieldLabel": nndss_label,
         }
     )
@@ -103,6 +105,7 @@ def update_field(
         name: str,
         new_name: str,
         description: str,
+        examples: str,
         nndss_label: str,
         typename: str,
         can_visualise: bool,
@@ -147,6 +150,9 @@ def update_field(
 
     if is_private is not None:
         patch_fields["isPrivate"] = is_private
+    
+    if examples is not None:
+        patch_fields["examples"] = examples
 
     api_patch(
         path=f"{TENANT_PATH}/{tenant_global_id}/{METADATACOLUMN_PATH}/{name}",

--- a/austrakka/utils/options.py
+++ b/austrakka/utils/options.py
@@ -87,6 +87,19 @@ def opt_private(is_update=False, **attrs: t.Any):
         **{**defaults, **attrs}
     )
 
+def opt_examples(var_name='examples', **attrs: t.Any):
+    defaults = {
+        'required': False,
+        'help': 'string of comma delimited examples values for the field',
+    }
+    return create_option(
+        "-e",
+        "--examples",
+        var_name,
+        type=click.STRING,
+        **{**defaults, **attrs}
+    )
+
 
 def opt_email_address(var_name='email', **attrs: t.Any):
     defaults = {


### PR DESCRIPTION
add and update now can optionally take the 'Examples' parameter to update or add examples to a new or existing fields.