### PR TITLE
Fixed the merge setting in project on the CLI

### DIFF
--- a/austrakka/components/project/funcs.py
+++ b/austrakka/components/project/funcs.py
@@ -6,7 +6,7 @@ from austrakka.utils.api import api_post, \
 from austrakka.utils.api import api_patch
 from austrakka.utils.api import api_put
 from austrakka.utils.helpers.output import call_get_and_print
-from austrakka.utils.helpers.project import get_project_by_abbrev
+from austrakka.utils.helpers.project import get_project_by_abbrev, get_project_settings_by_abbrev
 from austrakka.utils.misc import logger_wraps
 from austrakka.utils.output import print_response
 from austrakka.utils.paths import PROJECT_PATH, \
@@ -80,18 +80,21 @@ def update_project(
         merge_algorithm: str
 ):
     project = get_project_by_abbrev(project_abbreviation)
+    project_settings = get_project_settings_by_abbrev(project_abbreviation)
     
     # ProjectDTO fields which should go in ProjectPutDTO
-    put_project = {k: project[k] for k in [
-        'name',
-        'description',
-        'isActive',
-        'requestingOrg',
-        'dashboardName',
-        'type',
-        'clientType',
-        'mergeAlgorithm'
-    ]}
+    put_project = {
+        **{k: project[k] for k in [
+            'name',
+            'description',
+            'isActive',
+            'requestingOrg',
+            'dashboardName',
+            'type',
+            'clientType',
+        ]},
+        'mergeAlgorithm': project_settings['mergeAlgorithm'],
+    }
     
     if project['requestingOrg'] is None:
         put_project['requestingOrg'] = {'abbreviation': None}

--- a/austrakka/components/project/metadata/__init__.py
+++ b/austrakka/components/project/metadata/__init__.py
@@ -8,9 +8,7 @@ from austrakka.utils.options import opt_merge_algorithm
 from austrakka.utils.options import opt_view_id
 
 from .funcs import list_dataset_views, \
-    download_dataset_view, \
-    set_merge_algorithm_project
-
+    download_dataset_view
 
 @click.group()
 @click.pass_context
@@ -34,7 +32,6 @@ def get_dataset_view_list(project_abbrev: str, out_format: str):
     """Get a list of metadata views for a given project."""
     list_dataset_views(project_abbrev, out_format)
 
-
 @metadata.command('get')
 @opt_view_id()
 @click.argument('project-abbrev', type=str)
@@ -46,13 +43,3 @@ def get_dataset_view(
 ):
     """Get a specific metadata view. By default, the full metadata view is returned."""
     download_dataset_view(view_id, project_abbrev, out_format)
-
-
-@metadata.command('set-merge')
-@click.argument('project-abbrev', type=str)
-@opt_merge_algorithm()
-def project_set_merge_algo(project_abbrev: str, merge_algo):
-    """
-    Set merge algorithm to use when generating metadata views.
-    """
-    set_merge_algorithm_project(project_abbrev, merge_algo)

--- a/austrakka/components/project/metadata/funcs.py
+++ b/austrakka/components/project/metadata/funcs.py
@@ -5,7 +5,7 @@ from typing import Optional
 import httpx
 from httpx import HTTPStatusError
 from loguru import logger
-from austrakka.utils.api import api_get, api_get_stream, api_patch
+from austrakka.utils.api import api_get, api_get_stream
 from austrakka.utils.exceptions import FailedResponseException, UnknownResponseException
 from austrakka.utils.http import get_header_value, HEADERS
 from austrakka.utils.misc import logger_wraps
@@ -17,14 +17,6 @@ DATASET_UPLOAD_PATH = 'dataset'
 DATASET_ACK_PATH = 'acknowledge'
 DATASET_TRACK_PATH = 'dataset-progress'
 DATASET_TRACK_DETAILED_PATH = 'dataset-progress-details'
-
-
-@logger_wraps()
-def set_merge_algorithm_project(abbrev: str, merge_algo: str):
-
-    return api_patch(
-        path=f'{PROJECT_PATH}/{abbrev}/set-merge-algorithm/{merge_algo}'
-    )
 
 
 @logger_wraps()

--- a/austrakka/utils/helpers/project.py
+++ b/austrakka/utils/helpers/project.py
@@ -1,6 +1,9 @@
 from austrakka.utils.api import api_get
-from austrakka.utils.paths import PROJECT_PATH
+from austrakka.utils.paths import PROJECT_PATH, PROJECT_SETTINGS
 
 
 def get_project_by_abbrev(abbrev: str):
     return api_get(path=f"{PROJECT_PATH}/abbrev/{abbrev}")['data']
+
+def get_project_settings_by_abbrev(abbrev: str):
+    return api_get(path=f"{PROJECT_PATH}/{abbrev}/{PROJECT_SETTINGS}")['data']


### PR DESCRIPTION
This change now properly updates the merge algorithm, on the project update command. Thus, I removed the separate `set-merge-algorithm` command as its extra maintenance while being redundant.

This was the fastest solution to get prod up and running without touching the server.

Although this leads to future work of removing the dead hanging set algorithm endpoint and the rip out the project settings table as its leading to more usage problems than solving them.