### PR TITLE
AB#7322 - Changed 'proforma update' command to be 'proforma add-versi…

### DIFF
--- a/austrakka/components/proforma/__init__.py
+++ b/austrakka/components/proforma/__init__.py
@@ -8,6 +8,7 @@ from austrakka.utils.cmd_filter import hide_admin_cmds
 from .funcs import \
     add_proforma, \
     update_proforma, \
+    add_version_proforma, \
     list_proformas, \
     show_proforma, \
     disable_proforma, \
@@ -75,19 +76,36 @@ def proforma_add(
         optional_field)
 
 @proforma.command('update', hidden=hide_admin_cmds())
+@opt_name(required=False)
+@opt_description(required=False)
+@click.argument('proforma-abbrev', type=click.STRING)
+def proforma_update(
+        proforma_abbrev: str,
+        name: str,
+        description: str):
+    """
+    Update a pro forma's Name or Description
+    """
+    update_proforma(
+        proforma_abbrev,
+        name,
+        description)
+
+
+@proforma.command('add-version', hidden=hide_admin_cmds())
 @opt_required
 @opt_optional
 @click.argument('proforma-abbrev', type=click.STRING)
-def proforma_update(
+def proforma_add_version(
         proforma_abbrev: str,
         required_field: List[str],
         optional_field: List[str]):
     """
-    Update a proforma with a new set of fields.
+    Add a proforma version with a new set of fields.
     The fields specified by -req and -opt will fully replace the fields in the current version.
     Any fields in the current version but not listed in the update will be removed.
     """
-    update_proforma(
+    add_version_proforma(
         proforma_abbrev,
         required_field,
         optional_field)

--- a/austrakka/components/proforma/funcs.py
+++ b/austrakka/components/proforma/funcs.py
@@ -22,6 +22,7 @@ from ...utils.helpers.project import get_project_by_abbrev
 from ...utils.helpers.tenant import get_default_tenant_global_id
 
 ATTACH = 'Attach'
+UPDATE = 'update'
 
 
 @logger_wraps()
@@ -67,7 +68,26 @@ def unshare_proforma(abbrev: str, group_names: List[str]):
 
 
 @logger_wraps()
-def update_proforma(
+def update_proforma(abbrev: str, name: str, description: str):
+    # If both Name and Description are null or empty, it is an error
+    if not name and not description:
+        raise ValueError("Name and Description cannot both be empty")
+    
+    data = {}
+    if name:
+        data['name'] = name
+
+    if description:
+        data['description'] = description
+
+    api_patch(
+        path=f'{PROFORMA_PATH}/{abbrev}/{UPDATE}',
+        data=data,
+    )
+
+
+@logger_wraps()
+def add_version_proforma(
         abbrev: str,
         required_columns: List[str],
         optional_columns: List[str]):


### PR DESCRIPTION
…on'. Added new behaviour to for modifying only a proforma's properties, and assigning that behaviour to the 'proforma update' command.