### PR TITLE
Take owner org and shared projects as parameters

### DIFF
--- a/austrakka/components/metadata/__init__.py
+++ b/austrakka/components/metadata/__init__.py
@@ -6,7 +6,7 @@ from io import BufferedReader
 import click
 
 from austrakka import __prog_name__ as PROG_NAME
-from austrakka.utils.options import opt_proforma, opt_batch_size
+from austrakka.utils.options import opt_proforma, opt_batch_size, opt_owner_org, opt_share
 from austrakka.utils.options import opt_is_update
 from austrakka.utils.options import opt_group_name
 from austrakka.utils.options import opt_blanks_delete
@@ -36,16 +36,26 @@ def metadata(ctx):
 
 @metadata.command('add', help=f'Upload metadata submission to {PROG_NAME}')
 @click.argument('file', type=click.File('rb'))
+@opt_owner_org(required=True)
+@opt_share()
 @opt_proforma()
 @opt_blanks_delete()
 @opt_batch_size(help=ADD_APPEND_BATCH_SIZE_HELP,
                 default=5000)
 def submission_add(
         file: BufferedReader,
+        owner_org: str,
+        shared_projects: List[str],
         proforma: str,
         blanks_will_delete: bool,
         batch_size: int):
-    add_metadata(file, proforma, blanks_will_delete, batch_size)
+    add_metadata(
+        file, 
+        owner_org, 
+        shared_projects, 
+        proforma, 
+        blanks_will_delete, 
+        batch_size)
 
 
 @metadata.command('update', help=f"""
@@ -55,20 +65,31 @@ def submission_add(
     to be updated. All samples must already exist in {PROG_NAME}.
 """)
 @click.argument('file', type=click.File('rb'))
+@opt_owner_org(required=True)
+@opt_share()
 @opt_proforma()
 @opt_blanks_delete()
 @opt_batch_size(help=ADD_APPEND_BATCH_SIZE_HELP,
                 default=5000)
 def submission_append(
         file: BufferedReader, 
+        owner_org: str,
+        shared_projects: List[str],
         proforma: str, 
         blanks_will_delete: bool,
-        batch_size: int):
-    append_metadata(file, proforma, blanks_will_delete, batch_size)
+        batch_size: int):   
+    append_metadata(
+        file, 
+        owner_org, 
+        shared_projects, 
+        proforma, 
+        blanks_will_delete, 
+        batch_size)
 
 
 @metadata.command('validate')
 @click.argument('file', type=click.File('rb'))
+@opt_owner_org(required=True)
 @opt_proforma()
 @opt_is_update()
 @opt_batch_size(help='The number of rows to split the metadata upload into before uploading. '
@@ -76,10 +97,17 @@ def submission_append(
                      'Validation messages will be returned per batch.'
                      'A negative or 0 value can be used to indicate no batching.',
                 default=5000)
-def submission_validate(file: BufferedReader, proforma: str, is_update: bool, batch_size: int):
-    """Check uploaded content for errors and warnings. This is a read-only
-    action. No data will modified."""
-    validate_metadata(file, proforma, is_update, batch_size)
+def submission_validate(
+        file: BufferedReader, 
+        owner_org: str, 
+        proforma: str, 
+        is_update: bool, 
+        batch_size: int):
+    """
+    Check uploaded content for errors and warnings. This is a read-only
+    action. No data will modified.
+    """
+    validate_metadata(file, owner_org, proforma, is_update, batch_size)
 
 
 @metadata.command('list')

--- a/austrakka/components/metadata/funcs.py
+++ b/austrakka/components/metadata/funcs.py
@@ -22,9 +22,14 @@ DELETE_ON_BLANK_PARAM = 'deleteOnBlank=True'
 
 METADATA_BY_FIELD_PATH = 'by-field'
 
+OWNER_ORG_HEADER = 'X-Metadata-Owner-Org-Abbrev'
+SHARED_PROJECTS_HEADER = 'X-Metadata-Shared-Projects-Abbrev'
+
 @logger_wraps()
 def add_metadata(
         file: BufferedReader,
+        owner_org: str,
+        shared_projects: List[str],
         proforma_abbrev: str,
         blanks_will_delete: bool,
         batch_size: int,
@@ -32,41 +37,61 @@ def add_metadata(
     path = "/".join([SUBMISSION_PATH, SUBMISSION_UPLOAD])
     if blanks_will_delete:
         path = f"{path}?{DELETE_ON_BLANK_PARAM}"
-    _call_batched_submission(path, file, proforma_abbrev, batch_size)
+    _call_batched_submission(
+        path, 
+        file, 
+        owner_org, 
+        shared_projects, 
+        proforma_abbrev, 
+        batch_size)
 
 
 @logger_wraps()
 def append_metadata(
         file: BufferedReader,
+        owner_org: str,
+        shared_projects: List[str],
         proforma_abbrev: str,
         blanks_will_delete: bool,
         batch_size: int,
 ):
     path = "/".join([SUBMISSION_PATH, SUBMISSION_UPLOAD_APPEND])
+    
     if blanks_will_delete:
         path = f"{path}&{DELETE_ON_BLANK_PARAM}"
-    _call_batched_submission(path, file, proforma_abbrev, batch_size)
+        
+    _call_batched_submission(
+        path, 
+        file, 
+        owner_org, 
+        shared_projects, 
+        proforma_abbrev, 
+        batch_size)
 
 
 @logger_wraps()
 def validate_metadata(
         file: BufferedReader,
+        owner_org: str,
         proforma_abbrev: str,
         is_append: bool,
         batch_size: int,
 ):
     path = SUBMISSION_VALIDATE_APPEND if is_append else SUBMISSION_VALIDATE
     path = "/".join([SUBMISSION_PATH, path])
-    _call_batched_submission(path, file, proforma_abbrev, batch_size)
+    _call_batched_submission(path, file, owner_org, [], proforma_abbrev, batch_size)
+
 
 def _call_batched_submission(
         path: str,
         file: BufferedReader,
+        owner_org: str,
+        shared_projects: List[str],
         proforma_abbrev: str,
-        batch_size: int
-):
+        batch_size: int,
+):    
     if batch_size < 1:
-        _call_submission(path, file, proforma_abbrev)
+        _call_submission(path, file, owner_org, shared_projects, proforma_abbrev)
         return
     
     filepath = Path(file.name)
@@ -75,16 +100,17 @@ def _call_batched_submission(
         df = pd.read_csv(file, dtype=str, index_col=False, keep_default_na=False, na_values='')
     elif filepath.suffix == '.xlsx':
         # Batching not currently supported, just upload the original file
-        _call_submission(path, file, proforma_abbrev)
+        _call_submission(path, file, owner_org, shared_projects, proforma_abbrev)
         return
-    else:
+    
+    if filepath.suffix != '.csv':
         raise ValueError('File must be .csv or .xlsx')
     
     num_rows = df.shape[0]
     if num_rows <= batch_size:
         # Just upload the original file
         file.seek(0)
-        _call_submission(path, file, proforma_abbrev)
+        _call_submission(path, file, owner_org, shared_projects, proforma_abbrev)
         return
     
     logger.info(f"Uploading {num_rows} rows in batches of {batch_size}")
@@ -95,22 +121,30 @@ def _call_batched_submission(
         buffer = StringIO()
         buffer.name = f"{filepath.stem}_batch_rows{index}-{index+batch_size-1}.csv"
         chunk.to_csv(buffer, index=False)
-        _call_submission(path, encode(buffer), proforma_abbrev)
-    
+        _call_submission(path, encode(buffer), owner_org, shared_projects, proforma_abbrev)
+        
     logger.info("Batched upload complete")
 
 
 def _call_submission(
         path: str,
         file: BufferedReader,
+        owner_org: str,
+        shared_projects: List[str],
         proforma_abbrev: str,
 ):
+    headers = {OWNER_ORG_HEADER: owner_org,}
+    if shared_projects:
+        # TODO should we use a more standard form of multi value header?
+        headers[SHARED_PROJECTS_HEADER] = ";".join(shared_projects)
+
     api_post_multipart(
         path=path,
         data={
             'proforma-abbrev': proforma_abbrev,
         },
-        files={'file': (file.name, file)}
+        files={'file': (file.name, file)},
+        custom_headers=headers
     )
 
 

--- a/austrakka/components/sequence/add/__init__.py
+++ b/austrakka/components/sequence/add/__init__.py
@@ -1,10 +1,11 @@
 from io import BufferedReader
-from typing import Union
+from typing import List
 
 import click
 
 from austrakka.utils.enums.seq import SeqType
 from austrakka.utils.options import opt_force_mutex_skip
+from austrakka.utils.options import opt_owner_org
 from austrakka.utils.options import opt_skip_mutex_force
 from austrakka.utils.options import opt_owner
 from austrakka.utils.options import opt_share
@@ -38,21 +39,21 @@ def add(ctx):
     {METADATA_ADD_HELP_TEXT}
 """)
 @click.argument('csv_file', type=click.File('rb'))
+@opt_owner_org(required=True)
 @opt_skip_mutex_force(
     help="For each sample, skip upload if the sample has existing sequences of the same type.")
 @opt_force_mutex_skip(
     help="Upload sequences and supersede any existing sequences of the same type.")
-@opt_owner()
 @opt_share()
 # pylint: disable=invalid-name
 def seq_add_fastq_ill_PE(
         csv_file: BufferedReader,
+        owner_org: str,
+        shared_projects: List[str],
         skip: bool = False,
         force: bool = False,
-        owner_group: Union[str, None] = None,
-        shared_group: Union[str, None] = None,
 ):
-    add_sequence_submission(SeqType.FASTQ_ILL_PE, csv_file, skip, force, owner_group, shared_group)
+    add_sequence_submission(SeqType.FASTQ_ILL_PE, csv_file, owner_org, shared_projects, skip, force)
 
 
 @add.command(SeqType.FASTQ_ILL_SE.value, help=f"""
@@ -65,21 +66,21 @@ def seq_add_fastq_ill_PE(
     {METADATA_ADD_HELP_TEXT}
 """)
 @click.argument('csv_file', type=click.File('rb'))
+@opt_owner_org(required=True)
 @opt_skip_mutex_force(
     help="For each sample, skip upload if the sample has existing sequences of the same type.")
 @opt_force_mutex_skip(
     help="Upload sequences and supersede any existing sequences of the same type.")
-@opt_owner()
 @opt_share()
 # pylint: disable=invalid-name
 def seq_add_fastq_ill_SE(
         csv_file: BufferedReader,
+        owner_org: str,
+        shared_projects: List[str],
         skip: bool = False,
         force: bool = False,
-        owner_group: Union[str, None] = None,
-        shared_group: Union[str, None] = None,
 ):
-    add_sequence_submission(SeqType.FASTQ_ILL_SE, csv_file, skip, force, owner_group, shared_group)
+    add_sequence_submission(SeqType.FASTQ_ILL_SE, csv_file, owner_org, shared_projects, skip, force)
 
 
 @add.command(SeqType.FASTQ_ONT.value, help=f"""
@@ -92,20 +93,20 @@ def seq_add_fastq_ill_SE(
     {METADATA_ADD_HELP_TEXT}
 """)
 @click.argument('csv_file', type=click.File('rb'))
+@opt_owner_org(required=True)
 @opt_skip_mutex_force(
     help="For each sample, skip upload if the sample has existing sequences of the same type.")
 @opt_force_mutex_skip(
     help="Upload sequences and supersede any existing sequences of the same type.")
-@opt_owner()
 @opt_share()
 def seq_add_fastq_ont(
         csv_file: BufferedReader,
+        owner_org: str,
+        shared_projects: List[str],
         skip: bool = False,
         force: bool = False,
-        owner_group: Union[str, None] = None,
-        shared_group: Union[str, None] = None,
 ):
-    add_sequence_submission(SeqType.FASTQ_ONT, csv_file, skip, force, owner_group, shared_group)
+    add_sequence_submission(SeqType.FASTQ_ONT, csv_file, owner_org, shared_projects, skip, force)
 
 
 @add.command(SeqType.FASTA_CNS.value, help=f"""
@@ -118,22 +119,22 @@ def seq_add_fastq_ont(
     {METADATA_ADD_HELP_TEXT}
 """)
 @click.argument('fasta_file', type=click.File('rb'))
+@opt_owner_org(required=True)
 @opt_skip_mutex_force(
     help="For each sample, skip upload if the sample has existing sequences of the same type.")
 @opt_force_mutex_skip(
     help="Upload sequences and supersede any existing sequences of the same type.")
-@opt_owner()
 @opt_share()
 def seq_add_fasta_cns(
         fasta_file: BufferedReader,
+        owner_org: str,
+        shared_projects: List[str],
         skip: bool = False,
         force: bool = False,
-        owner_group: Union[str, None] = None,
-        shared_group: Union[str, None] = None,
 ):
     # FASTA-CNS is a special case as the CLI does the work of splitting the file,
     # and there is no CSV
-    add_fasta_cns_submission(fasta_file, skip, force, owner_group, shared_group)
+    add_fasta_cns_submission(fasta_file, owner_org, shared_projects, skip, force)
 
 
 @add.command(SeqType.FASTA_ASM.value, help=f"""
@@ -146,17 +147,17 @@ def seq_add_fasta_cns(
     {METADATA_ADD_HELP_TEXT}
 """)
 @click.argument('csv_file', type=click.File('rb'))
+@opt_owner_org(required=True)
 @opt_skip_mutex_force(
     help="For each sample, skip upload if the sample has existing sequences of the same type.")
 @opt_force_mutex_skip(
     help="Upload sequences and supersede any existing sequences of the same type.")
-@opt_owner()
 @opt_share()
 def seq_add_fasta_asm(
         csv_file: BufferedReader,
+        owner_org: str,
+        shared_projects: List[str],
         skip: bool = False,
         force: bool = False,
-        owner_group: Union[str, None] = None,
-        shared_group: Union[str, None] = None,
 ):
-    add_sequence_submission(SeqType.FASTA_ASM, csv_file, skip, force, owner_group, shared_group)
+    add_sequence_submission(SeqType.FASTA_ASM, csv_file, owner_org, shared_projects, skip, force)

--- a/austrakka/components/sequence/funcs.py
+++ b/austrakka/components/sequence/funcs.py
@@ -10,7 +10,6 @@ import hashlib
 from dataclasses import dataclass
 from typing import List
 from typing import Dict
-from typing import Union
 
 import httpx
 import pandas as pd
@@ -87,13 +86,13 @@ class SeqFile:
 @logger_wraps()
 def add_fasta_cns_submission(
         fasta_file: BufferedReader,
+        owner_org: str,
+        shared_projects: List[str],
         skip: bool = False,
         force: bool = False,
-        owner_group: Union[str, None] = None,
-        shared_group: Union[str, None] = None,
 ):
     """Iterate through a FASTA file and submit each sequence as a separate sample"""
-    _validate_streamlined_seq_args(owner_group, shared_group)
+    _validate_streamlined_seq_args(owner_org, shared_projects)
 
     name_prefix = _calc_name_prefix(fasta_file)
 
@@ -102,7 +101,7 @@ def add_fasta_cns_submission(
     total_upload_count = 0
     records = list(SeqIO.parse(TextIOWrapper(fasta_file), 'fasta'))
     seq_ids = [record.id for record in records]
-    _create_samples(seq_ids, owner_group, shared_group)
+    _create_samples(seq_ids, owner_org, shared_projects)
     for record in records:
         seq_id = record.id
         logger.info(f"Uploading {seq_id}")
@@ -150,20 +149,21 @@ def add_fasta_cns_submission(
 def add_sequence_submission(
         seq_type: SeqType,
         csv_file: BufferedReader,
+        owner_org: str,
+        shared_projects: List[str],
         skip: bool = False,
         force: bool = False,
-        owner_group: Union[str, None] = None,
-        shared_group: Union[str, None] = None,
 ):
     """
     Generic handling of uploading any sequence type.
     Handles the case where the user provides a CSV mapping Seq_IDs to files.
     """
-    _validate_streamlined_seq_args(owner_group, shared_group)
+    _validate_streamlined_seq_args(owner_org, shared_projects)
     csv_dataframe = _get_and_validate_csv(csv_file, seq_type)
 
     seq_ids = list(csv_dataframe['Seq_ID'])
-    _create_samples(seq_ids, owner_group, shared_group)
+    _create_samples(seq_ids, owner_org, shared_projects)
+    client_session_id = uuid.uuid4().hex
 
     messages = _validate_csv_sequence_submission(csv_dataframe, seq_type)
     if messages:
@@ -220,7 +220,6 @@ def purge_sequence(seq_id: str, seq_type: SeqType, skip: bool, force: bool, dele
         path=api_path,
         custom_headers=custom_headers
     )
-
 
 def _calc_name_prefix(fasta_file):
     original_filename = Path(fasta_file.name)
@@ -612,17 +611,19 @@ def _csv_columns(seq_type: SeqType):
 
 def _create_samples(
         seq_ids: List[str],
-        owner_group: Union[str, None],
-        shared_group: Union[str, None],
+        owner_org: str,
+        shared_groups: list[str],
 ) -> None:
-    if owner_group is None and shared_group is None:
-        return
     with tempfile.NamedTemporaryFile(suffix=".csv") as tmp:
         csv_str = StringIO()
         rows = [[METADATA_FIELD_SEQ_ID, METADATA_FIELD_OWNER_GROUP, METADATA_FIELD_SHARED_GROUPS]]
         for seq_id in seq_ids:
             logger.info(f"Creating sample with {METADATA_FIELD_SEQ_ID} {seq_id}")
-            rows.append([seq_id, owner_group, shared_group])
+            
+            # The owner_group column will be replaced by the server.
+            # it is still maintained for backwards compatibility to
+            # avoid impacting the users' agreed proformas.
+            rows.append([seq_id, 'dummy_owner', 'dummy_share'])
         csv.writer(csv_str).writerows(rows)
         csv_str.seek(0)
         with open(tmp.name, 'w', encoding='utf8') as file:
@@ -630,14 +631,21 @@ def _create_samples(
 
         with open(tmp.name, 'rb') as file:
             file.seek(0)
-            add_metadata(file, "Min", blanks_will_delete=False, batch_size=5000)
+            add_metadata(
+                file, 
+                owner_org, 
+                shared_groups, 
+                "Min", 
+                blanks_will_delete=False,
+                batch_size=5000)
 
 
 def _validate_streamlined_seq_args(
-        owner_group: Union[str, None],
-        shared_group: Union[str, None],
+        owner_org: str,
+        shared_groups: list[str],
 ):
-    if (shared_group is not None) and (owner_group is None):
-        raise CliArgumentException("Owner group has not been provided")
-    if (shared_group is None) and (owner_group is not None):
+    if shared_groups and (owner_org is None):
+        raise CliArgumentException("Owner organisation has not been provided")
+    
+    if (not shared_groups) and (owner_org is not None):
         logger.warning("Shared group has not been provided. New samples will not be shared.")

--- a/austrakka/utils/options.py
+++ b/austrakka/utils/options.py
@@ -178,14 +178,30 @@ def opt_group_name(var_name='group_name', **attrs: t.Any):
     )
 
 
-def opt_share(var_name='shared_group', **attrs: t.Any):
+def opt_share(**attrs: t.Any):
     defaults = {
         'required': False,
-        'help': 'Group to share with',
+        'help': 'List of project abbreviations to share samples with. '
+                'This applies to all samples in the csv.',
+        'multiple': True,
     }
     return create_option(
-        "--share",
-        var_name,
+        '-sps',
+        "--shared-projects",
+        type=click.STRING,
+        **{**defaults, **attrs}
+    )
+
+
+def opt_owner_org(**attrs: t.Any):
+    defaults = {
+        'required': False,
+        'help': 'Owner Organisation Abbreviation. Specifies the owner '
+                'who owns all samples in the csv.'
+    }
+    return create_option(
+        '-oo',
+        "--owner-org",
         type=click.STRING,
         **{**defaults, **attrs}
     )


### PR DESCRIPTION
Owner org and shared projects are command-line parameters for both sequence upload and metadata upload. Works with the updated endpoints, which ignore Owner_group and Shared_groups columns in the data itself.

The first commit is a subset of changes from the Events branch; subsequent commits will be separate changes.