### PR TITLE
Fixes to proforma commands

### DIFF
--- a/austrakka/components/proforma/funcs.py
+++ b/austrakka/components/proforma/funcs.py
@@ -13,13 +13,11 @@ from austrakka.utils.exceptions import FailedResponseException, UnknownResponseE
 from austrakka.utils.helpers.upload import upload_multipart
 from austrakka.utils.misc import logger_wraps
 from austrakka.utils.output import print_dataframe, log_response
-from austrakka.utils.helpers.fields import get_system_field_names_v2
 from austrakka.utils.paths import PROFORMA_PATH
 from austrakka.utils.retry import retry
 from austrakka.utils.fs import FileHash, get_hash
 from .proforma_generation_utils import generate_template
 from ...utils.helpers.project import get_project_by_abbrev
-from ...utils.helpers.tenant import get_default_tenant_global_id
 
 ATTACH = 'Attach'
 UPDATE = 'update'
@@ -142,21 +140,6 @@ def add_proforma(
         description: str,
         required_columns: List[str],
         optional_columns: List[str]):
-
-    # Include system fields (avoid an error from the endpoint; don't force CLI user to type them in)
-    # Note that we are not forcing system fields the user DOES include
-    # to set IsRequired
-    tenant_global_id = get_default_tenant_global_id()
-    system_fields = get_system_field_names_v2(tenant_global_id)
-    missing_system_fields = [
-        fieldname for fieldname in system_fields if fieldname not in required_columns +
-        optional_columns]
-    required_columns = list(required_columns)
-    for field in missing_system_fields:
-        logger.warning(
-            f"System field {field} must be included: adding to pro forma")
-        required_columns.append(field)
-
     column_names = (
         [{"name": col, "isRequired": True} for col in required_columns]
         + [{"name": col, "isRequired": False} for col in optional_columns])
@@ -372,20 +355,11 @@ def _validate_add_version_args(
             "The following fields have been specified as both required and optional: "
             f"{', '.join(conflicting_fields)}"
         )
-
     conflicting_fields = (set(required_columns) | set(optional_columns)) & set(remove_field)
     if conflicting_fields:
         raise ValueError(
             "The following fields have been specified as both to be added/updated and removed: "
             f"{', '.join(conflicting_fields)}"
-        )
-
-    system_fields = get_system_field_names_v2(get_default_tenant_global_id())
-    removed_system_fields = set(remove_field) & set(system_fields)
-    if removed_system_fields:
-        raise ValueError(
-            "The following system fields cannot be removed: "
-            f"{', '.join(removed_system_fields)}"
         )
 
 def _build_field_spec(
@@ -411,7 +385,7 @@ def _build_field_spec(
             del field_spec[field_name]
         else:
             logger.warning(
-                f"Field 'f{field_name}' specified for removal was not found in the pro forma."
+                f"Field '{field_name}' specified for removal was not found in the pro forma."
             )
     
     return field_spec

--- a/austrakka/components/proforma/funcs.py
+++ b/austrakka/components/proforma/funcs.py
@@ -92,7 +92,7 @@ def add_version_proforma(
         remove_field: List[str],
         inherit: bool):
 
-    _validate_add_version_args(required_columns, optional_columns, remove_field)
+    _validate_add_version_args(inherit, required_columns, optional_columns, remove_field)
 
     data = api_get(path=f'{PROFORMA_PATH}/abbrev/{abbrev}')['data']
     pf_id = data['proFormaId']
@@ -346,6 +346,7 @@ def _post_proforma(files, file_hash: FileHash, custom_headers: dict):
                      custom_headers=custom_headers)
 
 def _validate_add_version_args(
+        inherit: bool,
         required_columns: List[str],
         optional_columns: List[str],
         remove_field: List[str]):
@@ -360,6 +361,10 @@ def _validate_add_version_args(
         raise ValueError(
             "The following fields have been specified as both to be added/updated and removed: "
             f"{', '.join(conflicting_fields)}"
+        )
+    if not inherit and len(remove_field) > 0:
+        raise ValueError(
+            "The 'remove-field' option can only be used when 'inherit' is set."
         )
 
 def _build_field_spec(

--- a/austrakka/utils/helpers/fields.py
+++ b/austrakka/utils/helpers/fields.py
@@ -4,8 +4,6 @@ from austrakka.utils.paths import METADATACOLUMNS_PATH, TENANT_PATH, METADATACOL
 def get_field_by_name(name: str):
     return api_get(path=f"{METADATACOLUMNS_PATH}/name/{name}")['data']
 
-
 def get_field_by_name_v2(tenant_global_id:str, name: str):
     return api_get(
         path=f"{TENANT_PATH}/{tenant_global_id}/{METADATACOLUMN_PATH}/name/{name}")['data']
-

--- a/austrakka/utils/helpers/fields.py
+++ b/austrakka/utils/helpers/fields.py
@@ -1,7 +1,6 @@
 from austrakka.utils.api import api_get
 from austrakka.utils.paths import METADATACOLUMNS_PATH, TENANT_PATH, METADATACOLUMN_PATH
 
-
 def get_field_by_name(name: str):
     return api_get(path=f"{METADATACOLUMNS_PATH}/name/{name}")['data']
 
@@ -10,20 +9,3 @@ def get_field_by_name_v2(tenant_global_id:str, name: str):
     return api_get(
         path=f"{TENANT_PATH}/{tenant_global_id}/{METADATACOLUMN_PATH}/name/{name}")['data']
 
-
-def get_system_field_names():
-    response = api_get(
-        path=f"{METADATACOLUMNS_PATH}/SystemFields?lenient=True",
-    )
-    data = response['data'] if ('data' in response) else response
-    fieldnames = [col['columnName'] for col in data]
-    return fieldnames
-
-
-def get_system_field_names_v2(tenant_global_id: str):
-    response = api_get(
-        path=f"{TENANT_PATH}/{tenant_global_id}/{METADATACOLUMN_PATH}/SystemFields?lenient=True",
-    )
-    data = response['data'] if ('data' in response) else response
-    fieldnames = [col['columnName'] for col in data]
-    return fieldnames


### PR DESCRIPTION
* When creating a proforma, do not add Seq_ID or other system fields on behalf of the user. The user must do it manually, and the endpoint will return an error if not. This is less onerous now that managing proforma versions is easier.
* If the user tries to use `proforma add-version -rm field` without `--inherit`, raise an error; this is trying to remove a field when there are no existing fields specified and will result in a nonsensical error if not caught.
