### PR TITLE
Fix mismatch with server Tree PUT/POST DTOs

### DIFF
--- a/austrakka/components/tree/funcs.py
+++ b/austrakka/components/tree/funcs.py
@@ -28,7 +28,7 @@ def add_tree(
         data={
             'name': name,
             'description': description,
-            'projectAbbrev': project,
+            'project': project,
             'isActive': is_active,
             'abbreviation': abbrev
         }
@@ -54,7 +54,7 @@ def update_tree(
     if is_active is not None:
         tree['isActive'] = is_active
     if project is not None:
-        tree['projectAbbrev'] = project
+        tree['project'] = project
 
     api_put(
         path=f'{TREE_PATH}/{abbrev}',


### PR DESCRIPTION
Mismatch introduced when removing AbbrevDTO, causing "Project is required" error from server

# PR Checklist

- [ ] Ran test suite locally
- [ ] PR to update [development docs](https://github.com/AusTrakka/austrakka-dev-docs) if needed
- [ ] PR to update [user docs](https://github.com/AusTrakka/austrakka--docs) including changelog if needed

Double check the repo merge order [here](https://github.com/AusTrakka/austrakka-dev-docs/blob/master/Infra/Releases.md)
if you have companion PRs in other repositories.
