### PR TITLE
Cleaning up project update related methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [00.88.2] - Unreleased
+
+## Changed
+  - The project update command no longer accepts the 'isActive' parameter. 
+This change is due to enable and disable commands being already available for this purpose.
+  - The 'project_type' parameter is now called 'project_label'. 
+This will affect project add and project update commands.
+
+## Removed
+  - The 'project set-type' has been removed as project update encapsulates this functionality.
+
 ## [0.88.1] - 2026-06-19
 
 ### Added

--- a/austrakka/components/project/__init__.py
+++ b/austrakka/components/project/__init__.py
@@ -6,7 +6,7 @@ from austrakka.utils.output import object_format_option
 from austrakka.utils.cmd_filter import hide_admin_cmds
 from austrakka.utils.options import opt_abbrev, \
     opt_is_active, \
-    opt_type, \
+    opt_label, \
     opt_view_type, opt_project_client_type, opt_merge_algorithm
 from austrakka.utils.options import opt_name
 from austrakka.utils.options import opt_dashboard_name
@@ -19,9 +19,7 @@ from .funcs import disable_project, enable_project, list_projects, \
     add_project, \
     update_project, \
     set_dashboard, \
-    get_dashboard, \
-    set_project_type
-
+    get_dashboard
 from .dataset import dataset
 from .field import field
 from .metadata import metadata
@@ -53,7 +51,7 @@ project.add_command(privilege_subcommands(PROJECT_RESOURCE))
 @opt_description(required=False)
 @opt_organisation(help="Requesting organisation abbreviation", required=False)
 @opt_dashboard_name(required=False)
-@opt_type(required=False)
+@opt_label(required=False)
 @opt_project_client_type()
 @opt_merge_algorithm()
 def project_add(
@@ -62,7 +60,7 @@ def project_add(
         description: str,
         org: str,
         dashboard_name: str,
-        project_type: str,
+        project_label: str,
         client_type: str,
         merge_algo: str):
     add_project(abbrev,
@@ -70,7 +68,7 @@ def project_add(
                 description,
                 org,
                 dashboard_name,
-                project_type,
+                project_label,
                 client_type,
                 merge_algo)
 
@@ -86,7 +84,7 @@ def project_add(
 @opt_is_active(help="Set project active status", is_update=True, required=False)
 @opt_organisation(help="New requesting organisation abbreviation", required=False)
 @opt_dashboard_name(help="New dashboard", required=False)
-@opt_type(help="New project type", required=False)
+@opt_label(help="New project type", required=False)
 @opt_project_client_type(required=False)
 @opt_merge_algorithm(required=False)
 def project_update(
@@ -135,14 +133,6 @@ def dashboard_get(project_abbrev: str, out_format: str):
 @table_format_option()
 def projects_list(view_type: str,out_format: str):
     list_projects(view_type, out_format)
-
-
-@project.command('set-type')
-@click.argument('project-abbrev', type=str)
-@opt_type()
-def project_set_type(project_abbrev: str, project_type: str):
-    '''Set a type for a project'''
-    set_project_type(project_abbrev, project_type)
 
 
 @project.command('enable')

--- a/austrakka/components/project/__init__.py
+++ b/austrakka/components/project/__init__.py
@@ -81,7 +81,6 @@ def project_add(
 @click.argument('project-abbrev', type=str)
 @opt_name(help="New project name", required=False)
 @opt_description(help="New project description", required=False)
-@opt_is_active(help="Set project active status", is_update=True, required=False)
 @opt_organisation(help="New requesting organisation abbreviation", required=False)
 @opt_dashboard_name(help="New dashboard", required=False)
 @opt_label(help="New project type", required=False)
@@ -91,7 +90,6 @@ def project_update(
         project_abbrev: str,
         name: str,
         description: str,
-        is_active: bool,
         org: str,
         dashboard_name: str,
         project_type: str,
@@ -100,7 +98,6 @@ def project_update(
     update_project(project_abbrev,
                    name,
                    description,
-                   is_active,
                    org,
                    dashboard_name,
                    project_type,

--- a/austrakka/components/project/funcs.py
+++ b/austrakka/components/project/funcs.py
@@ -66,7 +66,6 @@ def update_project(
         project_abbreviation: str,
         name: str,
         description: str,
-        is_active: bool,
         org: str,
         dashboard_name: str,
         project_label: str,
@@ -80,7 +79,6 @@ def update_project(
         **{k: project[k] for k in [
             'name',
             'description',
-            'isActive',
             'requestingOrg',
             'dashboardName',
             'label',
@@ -96,8 +94,6 @@ def update_project(
         put_project['name'] = name
     if description is not None:
         put_project['description'] = description
-    if is_active is not None:
-        put_project['isActive'] = is_active
     if org is not None:
         put_project['requestingOrg'] = org
     if dashboard_name is not None:

--- a/austrakka/components/project/funcs.py
+++ b/austrakka/components/project/funcs.py
@@ -8,14 +8,13 @@ from austrakka.utils.helpers.project import get_project_by_abbrev
 from austrakka.utils.misc import logger_wraps
 from austrakka.utils.output import get_viewtype_columns
 from austrakka.utils.paths import PROJECT_PATH
-from austrakka.utils.paths import SET_TYPE
 from austrakka.utils.paths import SET_DASHBOARD
 from austrakka.utils.paths import ASSIGNED_DASHBOARD
 
 compact_fields = [
     "projectId",        # Project ID
     "abbreviation",     # Abbreviation or short name
-    "type",             # Type for the project
+    "label",             # Type for the project
     "isActive",         # Active status
     "name"              # Full name of the project
 ]
@@ -25,7 +24,7 @@ more_fields = [
     "projectId",        # Project ID
     "abbreviation",     # Abbreviation or short name
     "clientType",       # the 'secret' client type
-    "type",             # Type for the project
+    "label",             # Type for the project
     "isActive",         # Active status
     "name",             # Project name
     "description",      # Description of the project
@@ -43,7 +42,7 @@ def add_project(
         description: str,
         org: str,
         dashboard_name: str,
-        project_type: str,
+        project_label: str,
         client_type: str,
         merge_algo: str):
     return api_post(
@@ -55,7 +54,7 @@ def add_project(
             "isActive": True,
             "requestingOrg": org,
             "dashboardName": dashboard_name,
-            "type": project_type,
+            "label": project_label,
             "clientType": client_type,
             "mergeAlgorithm": merge_algo, 
        }
@@ -70,7 +69,7 @@ def update_project(
         is_active: bool,
         org: str,
         dashboard_name: str,
-        project_type: str,
+        project_label: str,
         client_type: str,
         merge_algorithm: str
 ):
@@ -84,7 +83,7 @@ def update_project(
             'isActive',
             'requestingOrg',
             'dashboardName',
-            'type',
+            'label',
             'clientType',
             'mergeAlgorithm'
         ]},
@@ -103,8 +102,8 @@ def update_project(
         put_project['requestingOrg'] = org
     if dashboard_name is not None:
         put_project['dashboardName'] = dashboard_name
-    if project_type is not None:
-        put_project['type'] = project_type
+    if project_label is not None:
+        put_project['label'] = project_label
     if client_type is not None:
         put_project['clientType'] = client_type
     if merge_algorithm is not None:
@@ -137,12 +136,6 @@ def list_projects(view_type: str, out_format: str):
 def get_dashboard(project_abbreviation: str, out_format: str):
     joined_path = '/'.join([PROJECT_PATH, ASSIGNED_DASHBOARD, project_abbreviation])
     call_get_and_print(joined_path, out_format)
-
-    
-@logger_wraps() 
-def set_project_type(abbrev: str, project_type: str):
-    path = '/'.join([PROJECT_PATH, abbrev, SET_TYPE])
-    api_patch(path, data=project_type,)
 
 @logger_wraps()
 def enable_project(abbrev: str):

--- a/austrakka/utils/options.py
+++ b/austrakka/utils/options.py
@@ -66,13 +66,13 @@ def opt_name(var_name='name', **attrs: t.Any):
         **{**defaults, **attrs}
     )
 
-def opt_type(var_name='project_type', help_string='Type string.', **attrs: t.Any):
+def opt_label(var_name='project_label', help_string='Type string.', **attrs: t.Any):
     defaults = {
         'help': help_string,
     }
     return create_option(
         "-t",
-        "--type",
+        "--label",
         var_name,
         type=click.STRING,
         **{**defaults, **attrs}

--- a/austrakka/utils/paths.py
+++ b/austrakka/utils/paths.py
@@ -23,7 +23,6 @@ PLOT_PATH = "Plots"
 PROJECT_DASHBOARD_PATH = 'ProjectDashboards'
 SET_DASHBOARD = 'set-dashboard'
 ASSIGNED_DASHBOARD = 'assigned-dashboard'
-SET_TYPE = 'set-type'
 TENANT_PATH = 'Tenant'
 MESSAGES_PATH = 'Message'
 SCOPES_PATH = 'Scopes'


### PR DESCRIPTION
The project update method now does not take isActive, the type property has been renamed to label, and the set-type endpoint has been removed as it is redundant and encapsulated within update project.


# PR Checklist

- [x] PR to update [user docs](https://github.com/AusTrakka/austrakka--docs) including changelog if needed

Double check the repo merge order [here](https://github.com/AusTrakka/austrakka-dev-docs/blob/master/Infra/Releases.md)
if you have companion PRs in other repositories.


https://github.com/AusTrakka/austrakka-portal/pull/2426
https://github.com/AusTrakka/austrakka-client/pull/850